### PR TITLE
Add the ability to use EnvFromSource for the container spec

### DIFF
--- a/api/v1alpha1/llamastackdistribution_types.go
+++ b/api/v1alpha1/llamastackdistribution_types.go
@@ -134,6 +134,7 @@ type ContainerSpec struct {
 	Port      int32                       `json:"port,omitempty"` // Defaults to 8321 if unset
 	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
 	Env       []corev1.EnvVar             `json:"env,omitempty"` // Runtime env vars (e.g., INFERENCE_MODEL)
+	EnvFrom   []corev1.EnvFromSource      `json:"envFrom,omitempty"` // Mounted runtime env vars
 	Command   []string                    `json:"command,omitempty"`
 	Args      []string                    `json:"args,omitempty"`
 }

--- a/config/crd/bases/llamastack.io_llamastackdistributions.yaml
+++ b/config/crd/bases/llamastack.io_llamastackdistributions.yaml
@@ -186,6 +186,45 @@ spec:
                           - name
                           type: object
                         type: array
+                      envFrom:
+                        items:
+                          description: EnvFromSource represents the source of a set
+                            of ConfigMaps
+                          properties:
+                            configMapRef:
+                              description: The ConfigMap to select from
+                              properties:
+                                name:
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap must
+                                    be defined
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            prefix:
+                              description: An optional identifier to prepend to each
+                                key in the ConfigMap. Must be a C_IDENTIFIER.
+                              type: string
+                            secretRef:
+                              description: The Secret to select from
+                              properties:
+                                name:
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret must be
+                                    defined
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        type: array
                       name:
                         default: llama-stack
                         type: string

--- a/controllers/resource_helper.go
+++ b/controllers/resource_helper.go
@@ -152,6 +152,7 @@ func configureContainerEnvironment(ctx context.Context, r *LlamaStackDistributio
 
 	// Finally, add the user provided env vars
 	container.Env = append(container.Env, instance.Spec.Server.ContainerSpec.Env...)
+	container.EnvFrom = append(container.EnvFrom, instance.Spec.Server.ContainerSpec.EnvFrom...)
 }
 
 // configureContainerMounts sets up volume mounts for the container.

--- a/controllers/resource_helper_test.go
+++ b/controllers/resource_helper_test.go
@@ -80,6 +80,13 @@ func TestBuildContainerSpec(t *testing.T) {
 							Env: []corev1.EnvVar{
 								{Name: "TEST_ENV", Value: "test-value"},
 							},
+							EnvFrom: []corev1.EnvFromSource{
+								{SecretRef: &corev1.SecretEnvSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "TEST-SECRET",
+									},
+								}},
+							},
 						},
 						Storage: &llamav1alpha1.StorageSpec{
 							MountPath: "/custom/path",
@@ -102,6 +109,13 @@ func TestBuildContainerSpec(t *testing.T) {
 				Env: []corev1.EnvVar{
 					{Name: "HF_HOME", Value: "/custom/path"},
 					{Name: "TEST_ENV", Value: "test-value"},
+				},
+				EnvFrom: []corev1.EnvFromSource{
+					{SecretRef: &corev1.SecretEnvSource{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "TEST-SECRET",
+						},
+					}},
 				},
 				VolumeMounts: []corev1.VolumeMount{{
 					Name:      "lls-storage",


### PR DESCRIPTION
Solves #150. Adds envFrom to the llamastackdistribution custom resource definition and carries it through to the container definition.