### PR TITLE
feat: add Dynamic Resource Allocation fields to OGXServer

### DIFF
--- a/api/v1beta1/ogxserver_cel_test.go
+++ b/api/v1beta1/ogxserver_cel_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -822,6 +823,61 @@ func TestCEL_ExternalAccessConfig(t *testing.T) {
 					ExternalAccess: &ExternalAccessConfig{
 						Enabled:  true,
 						Hostname: "example.com",
+					},
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			obj := validOGXServer(uniqueName(), ns)
+			tt.mutate(obj)
+			err := k8sClient.Create(context.Background(), obj)
+			if tt.wantError == "" {
+				if err != nil {
+					t.Fatalf("expected success, got: %v", err)
+				}
+				t.Cleanup(func() { _ = k8sClient.Delete(context.Background(), obj) })
+			} else {
+				requireCELError(t, err, tt.wantError)
+			}
+		})
+	}
+}
+
+func TestCEL_ResourceClaims(t *testing.T) {
+	ns := createCELTestNamespace(t, "cel-dra")
+	claimName := "gpu-claim"
+	templateName := "gpu-template"
+
+	tests := []struct {
+		name      string
+		mutate    func(*OGXServer)
+		wantError string
+	}{
+		{
+			name: "resourceClaims with resourceClaimName is valid",
+			mutate: func(o *OGXServer) {
+				o.Spec.Workload = &WorkloadSpec{
+					ResourceClaims: []corev1.PodResourceClaim{
+						{Name: "gpu", ResourceClaimName: &claimName},
+					},
+					Resources: &corev1.ResourceRequirements{
+						Claims: []corev1.ResourceClaim{{Name: "gpu"}},
+					},
+				}
+			},
+		},
+		{
+			name: "resourceClaims with resourceClaimTemplateName is valid",
+			mutate: func(o *OGXServer) {
+				o.Spec.Workload = &WorkloadSpec{
+					ResourceClaims: []corev1.PodResourceClaim{
+						{Name: "gpu", ResourceClaimTemplateName: &templateName},
+					},
+					Resources: &corev1.ResourceRequirements{
+						Claims: []corev1.ResourceClaim{{Name: "gpu"}},
 					},
 				}
 			},

--- a/api/v1beta1/ogxserver_types.go
+++ b/api/v1beta1/ogxserver_types.go
@@ -418,9 +418,18 @@ type WorkloadSpec struct {
 	// +optional
 	// +kubebuilder:validation:Minimum=1
 	Workers *int32 `json:"workers,omitempty"`
-	// Resources defines CPU/memory requests and limits.
+	// Resources defines CPU/memory requests and limits, and optional DRA
+	// resource claim references consumed by the OGX container.
 	// +optional
 	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
+	// ResourceClaims defines which ResourceClaims must be allocated and reserved
+	// before the Pod is allowed to start. Containers consume allocated resources
+	// by name via spec.workload.resources.claims.
+	// +optional
+	// +kubebuilder:validation:MinItems=1
+	// +listType=map
+	// +listMapKey=name
+	ResourceClaims []corev1.PodResourceClaim `json:"resourceClaims,omitempty"`
 	// Autoscaling configures HPA for the server pods.
 	// +optional
 	Autoscaling *AutoscalingSpec `json:"autoscaling,omitempty"`

--- a/api/v1beta1/ogxserver_types_test.go
+++ b/api/v1beta1/ogxserver_types_test.go
@@ -17,9 +17,12 @@ limitations under the License.
 package v1beta1
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -236,4 +239,39 @@ func TestValidateAdoptionAnnotation(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestWorkloadSpecResourceClaimsRoundTrip(t *testing.T) {
+	claimName := "gpu-claim"
+	templateName := "gpu-template"
+	spec := WorkloadSpec{
+		ResourceClaims: []corev1.PodResourceClaim{
+			{Name: "gpu", ResourceClaimName: &claimName},
+			{Name: "gpu-from-template", ResourceClaimTemplateName: &templateName},
+		},
+		Resources: &corev1.ResourceRequirements{
+			Claims: []corev1.ResourceClaim{
+				{Name: "gpu"},
+				{Name: "gpu-from-template"},
+			},
+		},
+	}
+
+	data, err := json.Marshal(spec)
+	require.NoError(t, err)
+
+	var got WorkloadSpec
+	require.NoError(t, json.Unmarshal(data, &got))
+	require.Len(t, got.ResourceClaims, 2)
+	require.Equal(t, "gpu", got.ResourceClaims[0].Name)
+	require.NotNil(t, got.ResourceClaims[0].ResourceClaimName)
+	require.Equal(t, claimName, *got.ResourceClaims[0].ResourceClaimName)
+	require.Equal(t, "gpu-from-template", got.ResourceClaims[1].Name)
+	require.NotNil(t, got.ResourceClaims[1].ResourceClaimTemplateName)
+	require.Equal(t, templateName, *got.ResourceClaims[1].ResourceClaimTemplateName)
+	require.NotNil(t, got.Resources)
+	require.Equal(t, []corev1.ResourceClaim{
+		{Name: "gpu"},
+		{Name: "gpu-from-template"},
+	}, got.Resources.Claims)
 }

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -2659,6 +2659,13 @@ func (in *WorkloadSpec) DeepCopyInto(out *WorkloadSpec) {
 		*out = new(corev1.ResourceRequirements)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.ResourceClaims != nil {
+		in, out := &in.ResourceClaims, &out.ResourceClaims
+		*out = make([]corev1.PodResourceClaim, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.Autoscaling != nil {
 		in, out := &in.Autoscaling, &out.Autoscaling
 		*out = new(AutoscalingSpec)

--- a/config/crd/bases/ogx.io_ogxservers.yaml
+++ b/config/crd/bases/ogx.io_ogxservers.yaml
@@ -6333,8 +6333,63 @@ spec:
                     format: int32
                     minimum: 0
                     type: integer
+                  resourceClaims:
+                    description: |-
+                      ResourceClaims defines which ResourceClaims must be allocated and reserved
+                      before the Pod is allowed to start. Containers consume allocated resources
+                      by name via spec.workload.resources.claims.
+                    items:
+                      description: |-
+                        PodResourceClaim references exactly one ResourceClaim, either directly
+                        or by naming a ResourceClaimTemplate which is then turned into a ResourceClaim
+                        for the pod.
+
+                        It adds a name to it that uniquely identifies the ResourceClaim inside the Pod.
+                        Containers that need access to the ResourceClaim reference it with this name.
+                      properties:
+                        name:
+                          description: |-
+                            Name uniquely identifies this resource claim inside the pod.
+                            This must be a DNS_LABEL.
+                          type: string
+                        resourceClaimName:
+                          description: |-
+                            ResourceClaimName is the name of a ResourceClaim object in the same
+                            namespace as this pod.
+
+                            Exactly one of ResourceClaimName and ResourceClaimTemplateName must
+                            be set.
+                          type: string
+                        resourceClaimTemplateName:
+                          description: |-
+                            ResourceClaimTemplateName is the name of a ResourceClaimTemplate
+                            object in the same namespace as this pod.
+
+                            The template will be used to create a new ResourceClaim, which will
+                            be bound to this pod. When this pod is deleted, the ResourceClaim
+                            will also be deleted. The pod name and resource name, along with a
+                            generated component, will be used to form a unique name for the
+                            ResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.
+
+                            This field is immutable and no changes will be made to the
+                            corresponding ResourceClaim by the control plane after creating the
+                            ResourceClaim.
+
+                            Exactly one of ResourceClaimName and ResourceClaimTemplateName must
+                            be set.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    minItems: 1
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
                   resources:
-                    description: Resources defines CPU/memory requests and limits.
+                    description: |-
+                      Resources defines CPU/memory requests and limits, and optional DRA
+                      resource claim references consumed by the OGX container.
                     properties:
                       claims:
                         description: |-

--- a/controllers/resource_helper.go
+++ b/controllers/resource_helper.go
@@ -157,7 +157,7 @@ func buildContainerSpec(
 func resolveContainerResources(instance *ogxiov1beta1.OGXServer, workers int32, workersSet bool) corev1.ResourceRequirements {
 	var resources corev1.ResourceRequirements
 	if instance.Spec.Workload != nil && instance.Spec.Workload.Resources != nil {
-		resources = *instance.Spec.Workload.Resources
+		resources = *instance.Spec.Workload.Resources.DeepCopy()
 	}
 	ensureRequests(&resources, workers)
 	if workersSet {
@@ -466,8 +466,24 @@ func configurePodStorage(
 	configurePodOverrides(instance, &podSpec)
 
 	configurePodScheduling(instance, &podSpec)
+	configureResourceClaims(instance, &podSpec)
 
 	return podSpec
+}
+
+func configureResourceClaims(instance *ogxiov1beta1.OGXServer, podSpec *corev1.PodSpec) {
+	if instance.Spec.Workload == nil || len(instance.Spec.Workload.ResourceClaims) == 0 {
+		return
+	}
+	podSpec.ResourceClaims = deepCopyPodResourceClaims(instance.Spec.Workload.ResourceClaims)
+}
+
+func deepCopyPodResourceClaims(claims []corev1.PodResourceClaim) []corev1.PodResourceClaim {
+	copied := make([]corev1.PodResourceClaim, len(claims))
+	for i := range claims {
+		copied[i] = *claims[i].DeepCopy()
+	}
+	return copied
 }
 
 // configureStorage handles storage volume configuration.

--- a/controllers/resource_helper_test.go
+++ b/controllers/resource_helper_test.go
@@ -458,3 +458,94 @@ func TestBuildHPASpec(t *testing.T) {
 	assert.Equal(t, int32(5), spec.MaxReplicas)
 	require.Len(t, spec.Metrics, 2)
 }
+
+func TestConfigureResourceClaims(t *testing.T) {
+	claimName := "gpu-claim"
+	templateName := "gpu-template"
+
+	t.Run("copies pod resource claims onto the pod spec", func(t *testing.T) {
+		instance := &ogxiov1beta1.OGXServer{
+			Spec: ogxiov1beta1.OGXServerSpec{
+				Distribution: ogxiov1beta1.DistributionSpec{Image: "x:latest"},
+				Workload: &ogxiov1beta1.WorkloadSpec{
+					ResourceClaims: []corev1.PodResourceClaim{
+						{Name: "gpu", ResourceClaimName: &claimName},
+						{Name: "gpu-from-template", ResourceClaimTemplateName: &templateName},
+					},
+				},
+			},
+		}
+		podSpec := &corev1.PodSpec{}
+		configureResourceClaims(instance, podSpec)
+
+		require.Len(t, podSpec.ResourceClaims, 2)
+		assert.Equal(t, "gpu", podSpec.ResourceClaims[0].Name)
+		require.NotNil(t, podSpec.ResourceClaims[0].ResourceClaimName)
+		assert.Equal(t, claimName, *podSpec.ResourceClaims[0].ResourceClaimName)
+		assert.Equal(t, "gpu-from-template", podSpec.ResourceClaims[1].Name)
+		require.NotNil(t, podSpec.ResourceClaims[1].ResourceClaimTemplateName)
+		assert.Equal(t, templateName, *podSpec.ResourceClaims[1].ResourceClaimTemplateName)
+	})
+
+	t.Run("does not set claims when workload is nil", func(t *testing.T) {
+		instance := &ogxiov1beta1.OGXServer{
+			Spec: ogxiov1beta1.OGXServerSpec{
+				Distribution: ogxiov1beta1.DistributionSpec{Image: "x:latest"},
+			},
+		}
+		podSpec := &corev1.PodSpec{}
+		configureResourceClaims(instance, podSpec)
+		assert.Nil(t, podSpec.ResourceClaims)
+	})
+
+	t.Run("does not set claims when resourceClaims is empty", func(t *testing.T) {
+		instance := &ogxiov1beta1.OGXServer{
+			Spec: ogxiov1beta1.OGXServerSpec{
+				Distribution: ogxiov1beta1.DistributionSpec{Image: "x:latest"},
+				Workload:     &ogxiov1beta1.WorkloadSpec{},
+			},
+		}
+		podSpec := &corev1.PodSpec{}
+		configureResourceClaims(instance, podSpec)
+		assert.Nil(t, podSpec.ResourceClaims)
+	})
+
+	t.Run("deep-copies claims so later mutations do not affect the pod spec", func(t *testing.T) {
+		instance := &ogxiov1beta1.OGXServer{
+			Spec: ogxiov1beta1.OGXServerSpec{
+				Distribution: ogxiov1beta1.DistributionSpec{Image: "x:latest"},
+				Workload: &ogxiov1beta1.WorkloadSpec{
+					ResourceClaims: []corev1.PodResourceClaim{
+						{Name: "gpu", ResourceClaimName: &claimName},
+					},
+				},
+			},
+		}
+		podSpec := &corev1.PodSpec{}
+		configureResourceClaims(instance, podSpec)
+
+		instance.Spec.Workload.ResourceClaims[0].Name = "mutated"
+		mutatedClaim := "other-claim"
+		instance.Spec.Workload.ResourceClaims[0].ResourceClaimName = &mutatedClaim
+
+		assert.Equal(t, "gpu", podSpec.ResourceClaims[0].Name)
+		require.NotNil(t, podSpec.ResourceClaims[0].ResourceClaimName)
+		assert.Equal(t, claimName, *podSpec.ResourceClaims[0].ResourceClaimName)
+	})
+}
+
+func TestBuildContainerSpecPreservesResourceClaims(t *testing.T) {
+	instance := &ogxiov1beta1.OGXServer{
+		Spec: ogxiov1beta1.OGXServerSpec{
+			Distribution: ogxiov1beta1.DistributionSpec{Image: "x:latest"},
+			Workload: &ogxiov1beta1.WorkloadSpec{
+				Resources: &corev1.ResourceRequirements{
+					Claims: []corev1.ResourceClaim{{Name: "gpu"}},
+				},
+			},
+		},
+	}
+	c := buildContainerSpec(t.Context(), nil, instance, "test-image:latest", nil, nil)
+	require.Len(t, c.Resources.Claims, 1)
+	assert.Equal(t, "gpu", c.Resources.Claims[0].Name)
+}

--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -1552,7 +1552,8 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `replicas` _integer_ | Replicas is the desired Pod replica count. | 1 | Minimum: 0 <br /> |
 | `workers` _integer_ | Workers configures the number of uvicorn worker processes. |  | Minimum: 1 <br /> |
-| `resources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#resourcerequirements-v1-core)_ | Resources defines CPU/memory requests and limits. |  |  |
+| `resources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#resourcerequirements-v1-core)_ | Resources defines CPU/memory requests and limits, and optional DRA<br />resource claim references consumed by the OGX container. |  |  |
+| `resourceClaims` _[PodResourceClaim](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#podresourceclaim-v1-core) array_ | ResourceClaims defines which ResourceClaims must be allocated and reserved<br />before the Pod is allowed to start. Containers consume allocated resources<br />by name via spec.workload.resources.claims. |  | MinItems: 1 <br /> |
 | `autoscaling` _[AutoscalingSpec](#autoscalingspec)_ | Autoscaling configures HPA for the server pods. |  |  |
 | `storage` _[PVCStorageSpec](#pvcstoragespec)_ | Storage defines PVC configuration. |  |  |
 | `podDisruptionBudget` _[PodDisruptionBudgetSpec](#poddisruptionbudgetspec)_ | PodDisruptionBudget controls voluntary disruption tolerance. |  |  |

--- a/release/operator-openshift.yaml
+++ b/release/operator-openshift.yaml
@@ -6342,8 +6342,63 @@ spec:
                     format: int32
                     minimum: 0
                     type: integer
+                  resourceClaims:
+                    description: |-
+                      ResourceClaims defines which ResourceClaims must be allocated and reserved
+                      before the Pod is allowed to start. Containers consume allocated resources
+                      by name via spec.workload.resources.claims.
+                    items:
+                      description: |-
+                        PodResourceClaim references exactly one ResourceClaim, either directly
+                        or by naming a ResourceClaimTemplate which is then turned into a ResourceClaim
+                        for the pod.
+
+                        It adds a name to it that uniquely identifies the ResourceClaim inside the Pod.
+                        Containers that need access to the ResourceClaim reference it with this name.
+                      properties:
+                        name:
+                          description: |-
+                            Name uniquely identifies this resource claim inside the pod.
+                            This must be a DNS_LABEL.
+                          type: string
+                        resourceClaimName:
+                          description: |-
+                            ResourceClaimName is the name of a ResourceClaim object in the same
+                            namespace as this pod.
+
+                            Exactly one of ResourceClaimName and ResourceClaimTemplateName must
+                            be set.
+                          type: string
+                        resourceClaimTemplateName:
+                          description: |-
+                            ResourceClaimTemplateName is the name of a ResourceClaimTemplate
+                            object in the same namespace as this pod.
+
+                            The template will be used to create a new ResourceClaim, which will
+                            be bound to this pod. When this pod is deleted, the ResourceClaim
+                            will also be deleted. The pod name and resource name, along with a
+                            generated component, will be used to form a unique name for the
+                            ResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.
+
+                            This field is immutable and no changes will be made to the
+                            corresponding ResourceClaim by the control plane after creating the
+                            ResourceClaim.
+
+                            Exactly one of ResourceClaimName and ResourceClaimTemplateName must
+                            be set.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    minItems: 1
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
                   resources:
-                    description: Resources defines CPU/memory requests and limits.
+                    description: |-
+                      Resources defines CPU/memory requests and limits, and optional DRA
+                      resource claim references consumed by the OGX container.
                     properties:
                       claims:
                         description: |-

--- a/release/operator.yaml
+++ b/release/operator.yaml
@@ -6343,8 +6343,63 @@ spec:
                     format: int32
                     minimum: 0
                     type: integer
+                  resourceClaims:
+                    description: |-
+                      ResourceClaims defines which ResourceClaims must be allocated and reserved
+                      before the Pod is allowed to start. Containers consume allocated resources
+                      by name via spec.workload.resources.claims.
+                    items:
+                      description: |-
+                        PodResourceClaim references exactly one ResourceClaim, either directly
+                        or by naming a ResourceClaimTemplate which is then turned into a ResourceClaim
+                        for the pod.
+
+                        It adds a name to it that uniquely identifies the ResourceClaim inside the Pod.
+                        Containers that need access to the ResourceClaim reference it with this name.
+                      properties:
+                        name:
+                          description: |-
+                            Name uniquely identifies this resource claim inside the pod.
+                            This must be a DNS_LABEL.
+                          type: string
+                        resourceClaimName:
+                          description: |-
+                            ResourceClaimName is the name of a ResourceClaim object in the same
+                            namespace as this pod.
+
+                            Exactly one of ResourceClaimName and ResourceClaimTemplateName must
+                            be set.
+                          type: string
+                        resourceClaimTemplateName:
+                          description: |-
+                            ResourceClaimTemplateName is the name of a ResourceClaimTemplate
+                            object in the same namespace as this pod.
+
+                            The template will be used to create a new ResourceClaim, which will
+                            be bound to this pod. When this pod is deleted, the ResourceClaim
+                            will also be deleted. The pod name and resource name, along with a
+                            generated component, will be used to form a unique name for the
+                            ResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.
+
+                            This field is immutable and no changes will be made to the
+                            corresponding ResourceClaim by the control plane after creating the
+                            ResourceClaim.
+
+                            Exactly one of ResourceClaimName and ResourceClaimTemplateName must
+                            be set.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    minItems: 1
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
                   resources:
-                    description: Resources defines CPU/memory requests and limits.
+                    description: |-
+                      Resources defines CPU/memory requests and limits, and optional DRA
+                      resource claim references consumed by the OGX container.
                     properties:
                       claims:
                         description: |-


### PR DESCRIPTION
- Added `spec.workload.resourceClaims`([]corev1.PodResourceClaim) on WorkloadSpec. .
- The controller copies those claims onto the Deployment pod template, and still passes `spec.workload.resources.claims` through to the OGX container.
- Regenerated CRDs, DeepCopy, API docs, and installer YAML.
- Tests cover JSON round-trip, controller plumbing, container claim pass-through, and CRD admission.
-  Example:
```
apiVersion: ogx.io/v1beta1
kind: OGXServer
metadata:
  name: ogxserver-dra
spec:
  distribution:
    name: starter
  workload:
    resourceClaims:
      - name: gpu
        resourceClaimName: gpu-claim
        # or: resourceClaimTemplateName: gpu-template
    resources:
      claims:
        - name: gpu
      requests:
        cpu: 500m
        memory: 1Gi
```