### PR TITLE
feat: add Praxis-fronted internal-only deployment mode for OGXServer

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This repo hosts a Kubernetes operator that creates and manages OGX (Open GenAI S
     - [Installation](#installation)
     - [Deploying the OGX Server](#deploying-the-ogx-server)
     - [Runtime Config via CR](#runtime-config-via-cr)
-- [Enabling Network Policies](#enabling-network-policies)
+- [Network Policies (internal-only / Praxis-fronted)](#network-policies-internal-only--praxis-fronted)
 - [Monitoring](#monitoring)
 - [Developer Guide](#developer-guide)
     - [Prerequisites](#prerequisites)
@@ -184,9 +184,57 @@ kubectl apply -f config/samples/example-with-configmap.yaml
 
 `spec.overrideConfig` always takes precedence over declarative generation fields.
 
-## Enabling Network Policies
+## Network Policies (internal-only / Praxis-fronted)
 
-Network policies are enabled by default per-CR. Configure via `spec.network.policy`:
+OGX is an **internal-only backend**: in the target topology it is fronted by Praxis, which is
+the sole public entrypoint. The operator can enforce this at the network layer via
+**Praxis-fronted mode**.
+
+### Praxis-fronted mode (`spec.praxisMode`)
+
+`spec.praxisMode.enabled` is a tri-state per-CR switch:
+
+- **`true`** — Praxis-fronted (internal-only): the locked-down NetworkPolicy below, and no
+  external exposure.
+- **`false`** — legacy behavior: the pre-Praxis NetworkPolicy peers (all pods in the same
+  namespace + the OpenShift router) and `network.externalAccess.enabled` is honored (an Ingress
+  is created when enabled).
+- **unset** — a brand-new (greenfield) install has `spec.praxisMode.enabled` defaulted to `true`
+  by the operator's **mutating admission webhook** on create, so it adopts Praxis-fronted mode. A
+  CR created before the webhook existed (i.e. across an operator upgrade) keeps an unset value,
+  which is treated as legacy so the upgrade does not silently cut off co-located workloads. Because
+  the default is applied per-CR at create time, different OGXServers can migrate independently.
+
+> The `spec.praxisMode` API (the `enabled`, `praxisSelector`, and `migrationJob` fields and the
+> mutating webhook defaulter) is introduced by [#355](https://github.com/ogx-ai/ogx-k8s-operator/pull/355)
+> (RHAIENG-7193); this operator wiring consumes it.
+
+The rest of this section describes **Praxis mode**. In Praxis mode, for every OGXServer the
+operator creates a `NetworkPolicy` whose ingress on the service port (`8321`) admits traffic
+**only** from:
+
+1. **Praxis pods** — identified per-CR by `spec.praxisMode.praxisSelector` (see below), defaulting
+   to pods labeled `app: payload-processing` (the MaaS Gateway contract). This is the only
+   *application* traffic OGX accepts.
+2. **The operator namespace** — so the operator can poll OGX status (`/v1/providers`,
+   `/v1/version`). This is control-plane traffic, not application traffic.
+
+The broad "all pods in the same namespace" rule and the OpenShift router rule are **not**
+included, and the operator does **not** create any external exposure (Ingress) for OGX.
+Setting `spec.network.externalAccess.enabled: true` is **not honored** in Praxis mode — it is
+treated as `false` and surfaced as an admission warning (rather than a hard rejection, so
+existing CRs and GitOps applies keep working). `status.serviceURL` is populated with the
+internal cluster DNS endpoint; `status.externalURL` is empty. (In legacy mode, external access
+is honored and `status.externalURL` reflects the created Ingress.)
+
+In Praxis mode the operator also disables the **Responses API** in OGX's generated config (it is
+served by Praxis instead). This is applied internally during config generation and does **not**
+mutate your CR's `spec.disabledAPIs`.
+
+### Adding your own ingress rules (additive)
+
+`spec.network.policy.ingress` rules are **appended on top of** the mandatory Praxis + operator
+rules — they cannot remove the lock-down:
 
 ```yaml
 apiVersion: ogx.io/v1beta1
@@ -197,9 +245,6 @@ spec:
   distribution:
     name: starter
   network:
-    externalAccess:
-      enabled: true
-      hostname: my-ogx.example.com
     policy:
       enabled: true
       ingress:
@@ -212,12 +257,46 @@ spec:
               port: 8321
 ```
 
+To fully disable the NetworkPolicy (emergency escape hatch), set
+`spec.network.policy.enabled: false`.
+
+### Configuring the Praxis peer (per-CR)
+
+Which pods count as "Praxis" is configured **per-CR** via `spec.praxisMode.praxisSelector` — a
+namespace plus a Pod label selector. It becomes the NetworkPolicy ingress peer, so different
+OGXServers can point at different Praxis instances independently. If omitted, the operator fails
+safe to pods labeled `app: payload-processing` in the `openshift-ingress` namespace (never an
+allow-all peer):
+
+```yaml
+apiVersion: ogx.io/v1beta1
+kind: OGXServer
+metadata:
+  name: my-ogxserver
+spec:
+  distribution:
+    name: starter
+  praxisMode:
+    enabled: true
+    praxisSelector:
+      namespace: praxis
+      podSelector:
+        matchLabels:
+          app: payload-processing
+```
+
+> **Note (Praxis namespace):** the fail-safe default peer pins the `openshift-ingress` namespace,
+> matching where the PoC operator places the Praxis/extproc servers. This is **provisional and
+> pending confirmation with the MaaS team** — if Praxis runs elsewhere, set `praxisSelector` with
+> the correct `namespace`.
+
 | Field | Description |
 |-------|-------------|
-| `network.externalAccess.enabled` | When `true`, enables external access configuration for the server |
-| `network.externalAccess.hostname` | Hostname used for external access (for example, Ingress host) |
-| `network.policy.enabled` | When `true`, the operator creates a `NetworkPolicy` for the OGXServer workload |
-| `network.policy.ingress` | Ingress rules for the policy (for example, allowed sources and ports) |
+| `praxisMode.enabled` | Tri-state per-CR switch for Praxis-fronted (internal-only) mode: `true` (force on), `false` (force legacy), or unset (defaulted to `true` on create by the mutating webhook for new CRs; left unset — i.e. legacy — for CRs predating the webhook). |
+| `praxisMode.praxisSelector` | Per-CR `NetworkPolicyPeer` (namespace + pod selector) identifying the Praxis instance. Fails safe to `app: payload-processing` in the `openshift-ingress` namespace when omitted. |
+| `network.policy.enabled` | When `true` (default), the operator creates a `NetworkPolicy` for the OGXServer workload. Set to `false` to disable it entirely. |
+| `network.policy.ingress` | In Praxis mode, additional ingress rules appended to the mandatory Praxis + operator rules. In legacy mode, rules that replace the defaults. |
+| `network.externalAccess.enabled` | Honored only in legacy mode. In Praxis mode it is not honored (admission warning; no external exposure created). |
 
 ## Monitoring
 

--- a/api/v1beta1/ogxserver_types.go
+++ b/api/v1beta1/ogxserver_types.go
@@ -42,6 +42,20 @@ const (
 	DefaultLabelKey = "app"
 	// DefaultLabelValue is the default value for labels.
 	DefaultLabelValue = "ogx"
+	// DefaultPraxisPodLabelValue is the value of the "app" label identifying Praxis
+	// (MaaS Gateway) pods. Praxis is the only application workload permitted to reach
+	// OGX; this value is used as the fail-safe NetworkPolicy ingress peer when a CR's
+	// spec.praxisMode.praxisSelector is not set.
+	DefaultPraxisPodLabelValue = "payload-processing"
+	// DefaultPraxisNamespace is the namespace Praxis (MaaS) pods run in by default. The PoC
+	// operator places the extproc/Praxis servers in openshift-ingress, so the fail-safe
+	// NetworkPolicy peer pins its namespaceSelector to this namespace. This is provisional and
+	// pending confirmation with the MaaS team; override it per-CR via
+	// spec.praxisMode.praxisSelector if Praxis runs elsewhere.
+	DefaultPraxisNamespace = "openshift-ingress"
+	// DefaultNamespaceNameLabel is the well-known Kubernetes label the API server sets on every
+	// namespace to its own name; it is used to select a namespace by name in a NetworkPolicy peer.
+	DefaultNamespaceNameLabel = "kubernetes.io/metadata.name"
 	// DefaultMountPath is the default mount path for storage.
 	DefaultMountPath = "/.ogx"
 	// OGXServerKind is the kind name for OGXServer resources.
@@ -248,15 +262,12 @@ type TLSClientConfig struct {
 
 // NetworkPolicySpec configures the operator-managed NetworkPolicy for this server.
 //
-// Ingress is always enforced unless explicitly omitted from policyTypes.
-// The operator always includes default ingress rules (allow from same-namespace
-// and operator-namespace on the service port), merging them with any
-// user-specified rules.
+// The operator always enforces a mandatory ingress lock-down: OGX accepts traffic on the
+// service port only from Praxis pods (the internal API front-end) plus the operator
+// namespace (control-plane status polling). These mandatory rules cannot be removed via this
+// spec; set Enabled=false to disable the NetworkPolicy entirely as an escape hatch.
 //
-// Egress is unrestricted by default. It is only enforced when egress rules
-// are provided or "Egress" is explicitly included in policyTypes.
-// When any egress rules are configured, or when "Egress" is explicitly included in
-// policyTypes, a kube-dns egress rule is auto-injected to prevent DNS breakage.
+// Egress is unrestricted by default. It is only enforced when egress rules are provided.
 type NetworkPolicySpec struct {
 	// Enabled controls whether the operator manages a NetworkPolicy for this server.
 	// Defaults to true. Set to false to disable NetworkPolicy creation entirely.
@@ -270,8 +281,9 @@ type NetworkPolicySpec struct {
 	// +optional
 	// +kubebuilder:validation:items:Enum=Ingress;Egress
 	PolicyTypes []networkingv1.PolicyType `json:"policyTypes,omitempty"`
-	// Ingress defines additional ingress rules, merged with operator defaults
-	// (allow from same-namespace and operator-namespace on the service port).
+	// Ingress defines additional ingress rules, appended to the mandatory operator rules
+	// (allow from Praxis pods and the operator namespace on the service port). User rules
+	// are additive and cannot remove the mandatory Praxis lock-down.
 	// +optional
 	Ingress []networkingv1.NetworkPolicyIngressRule `json:"ingress,omitempty"`
 	// Egress rules. When non-empty, a kube-dns egress rule is auto-injected

--- a/api/v1beta1/ogxserver_webhook.go
+++ b/api/v1beta1/ogxserver_webhook.go
@@ -57,9 +57,6 @@ func SetupWebhookWithManager(mgr ctrl.Manager, knownDistNames []string) error {
 }
 
 //nolint:lll // kubebuilder marker cannot be split across lines.
-//+kubebuilder:webhook:path=/validate-ogx-io-v1beta1-ogxserver,mutating=false,failurePolicy=fail,sideEffects=None,groups=ogx.io,resources=ogxservers,verbs=create;update,versions=v1beta1,name=vogxserver.kb.io,admissionReviewVersions=v1
-
-//nolint:lll // kubebuilder marker cannot be split across lines.
 //+kubebuilder:webhook:path=/mutate-ogx-io-v1beta1-ogxserver,mutating=true,failurePolicy=fail,sideEffects=None,groups=ogx.io,resources=ogxservers,verbs=create,versions=v1beta1,name=mogxserver.kb.io,admissionReviewVersions=v1
 
 // Default implements admission.Defaulter. It only runs on CREATE (per the
@@ -74,6 +71,9 @@ func (d *OGXServerDefaulter) Default(_ context.Context, r *OGXServer) error {
 	}
 	return nil
 }
+
+//nolint:lll // kubebuilder marker cannot be split across lines.
+//+kubebuilder:webhook:path=/validate-ogx-io-v1beta1-ogxserver,mutating=false,failurePolicy=fail,sideEffects=None,groups=ogx.io,resources=ogxservers,verbs=create;update,versions=v1beta1,name=vogxserver.kb.io,admissionReviewVersions=v1
 
 // ValidateCreate implements admission.Validator.
 func (v *OGXServerValidator) ValidateCreate(_ context.Context, r *OGXServer) (admission.Warnings, error) {
@@ -93,11 +93,41 @@ func (v *OGXServerValidator) ValidateDelete(_ context.Context, _ *OGXServer) (ad
 }
 
 func (v *OGXServerValidator) validate(r *OGXServer) (admission.Warnings, error) {
+	warnings := collectValidationWarnings(r)
+
 	allErrs := v.collectValidationErrors(r)
 	if len(allErrs) > 0 {
-		return nil, allErrs.ToAggregate()
+		return warnings, allErrs.ToAggregate()
 	}
-	return nil, nil
+	return warnings, nil
+}
+
+// collectValidationWarnings returns non-fatal admission warnings. When an OGXServer opts into
+// Praxis-fronted mode (spec.praxisMode.enabled: true), OGX is internal-only and requesting external
+// access is not honored: the operator does not create any external exposure. This is surfaced as a
+// warning rather than a rejection so existing CRs and GitOps applies do not break.
+//
+// The warning is emitted only when Praxis mode is enabled. On create the mutating webhook has
+// already defaulted an unset spec.praxisMode to enabled, so this reflects the effective mode; when
+// Praxis mode is disabled (or unset on an upgrade, meaning legacy), external access may be honored,
+// so a warning would be misleading.
+func collectValidationWarnings(r *OGXServer) admission.Warnings {
+	var warnings admission.Warnings
+
+	externalAccessRequested := r.Spec.Network != nil &&
+		r.Spec.Network.ExternalAccess != nil &&
+		r.Spec.Network.ExternalAccess.Enabled
+	praxisModeEnabled := r.Spec.PraxisMode != nil &&
+		r.Spec.PraxisMode.Enabled != nil && *r.Spec.PraxisMode.Enabled
+
+	if externalAccessRequested && praxisModeEnabled {
+		warnings = append(warnings,
+			"spec.network.externalAccess.enabled is not honored: OGX is internal-only (Praxis-fronted, "+
+				"spec.praxisMode.enabled: true) and the operator does not create external exposure. "+
+				"This value is treated as false.")
+	}
+
+	return warnings
 }
 
 func (v *OGXServerValidator) collectValidationErrors(r *OGXServer) field.ErrorList {

--- a/api/v1beta1/ogxserver_webhook_test.go
+++ b/api/v1beta1/ogxserver_webhook_test.go
@@ -743,3 +743,69 @@ func TestMutatingWebhookOnlyFiresOnCreate(t *testing.T) {
 		}
 	}
 }
+
+func TestValidate_ExternalAccessWarning(t *testing.T) {
+	v := &OGXServerValidator{KnownDistributionNames: []string{"starter"}}
+
+	tests := []struct {
+		name        string
+		network     *NetworkSpec
+		praxisMode  *PraxisModeSpec
+		wantWarning bool
+	}{
+		{
+			name:        "no network spec: no warning",
+			network:     nil,
+			wantWarning: false,
+		},
+		{
+			name:        "external access disabled: no warning",
+			network:     &NetworkSpec{ExternalAccess: &ExternalAccessConfig{Enabled: false}},
+			praxisMode:  &PraxisModeSpec{Enabled: ptr(true)},
+			wantWarning: false,
+		},
+		{
+			name:        "external access enabled + praxis mode enabled: warns but does not reject",
+			network:     &NetworkSpec{ExternalAccess: &ExternalAccessConfig{Enabled: true}},
+			praxisMode:  &PraxisModeSpec{Enabled: ptr(true)},
+			wantWarning: true,
+		},
+		{
+			name:        "external access enabled + praxisMode unset: no warning (legacy)",
+			network:     &NetworkSpec{ExternalAccess: &ExternalAccessConfig{Enabled: true}},
+			praxisMode:  nil,
+			wantWarning: false,
+		},
+		{
+			name:        "external access enabled + praxis mode disabled: no warning (legacy honors it)",
+			network:     &NetworkSpec{ExternalAccess: &ExternalAccessConfig{Enabled: true}},
+			praxisMode:  &PraxisModeSpec{Enabled: ptr(false)},
+			wantWarning: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := &OGXServer{
+				Spec: OGXServerSpec{
+					Distribution: DistributionSpec{Name: "starter"},
+					Network:      tt.network,
+					PraxisMode:   tt.praxisMode,
+				},
+			}
+
+			warnings, err := v.ValidateCreate(t.Context(), server)
+			if err != nil {
+				t.Fatalf("ValidateCreate returned unexpected error: %v", err)
+			}
+
+			got := len(warnings) > 0
+			if got != tt.wantWarning {
+				t.Errorf("ValidateCreate warnings = %v, wantWarning %v", warnings, tt.wantWarning)
+			}
+			if tt.wantWarning && !strings.Contains(strings.Join(warnings, " "), "externalAccess") {
+				t.Errorf("expected warning to mention externalAccess, got %v", warnings)
+			}
+		})
+	}
+}

--- a/cmd/configgen/main.go
+++ b/cmd/configgen/main.go
@@ -99,7 +99,12 @@ func run(opts options) (*config.GeneratedConfig, error) {
 		return nil, fmt.Errorf("failed to validate secret ref env var names: %w", err)
 	}
 
-	return config.GenerateConfig(&server.Spec, baseConfigData)
+	// Resolve Praxis-fronted mode directly from the spec. This offline tool does not run the
+	// mutating webhook that defaults spec.praxisMode.enabled on create, so an unset value is
+	// treated as legacy.
+	praxisMode := server.Spec.PraxisMode != nil &&
+		server.Spec.PraxisMode.Enabled != nil && *server.Spec.PraxisMode.Enabled
+	return config.GenerateConfig(&server.Spec, baseConfigData, praxisMode)
 }
 
 type options struct {

--- a/config/crd/bases/ogx.io_ogxservers.yaml
+++ b/config/crd/bases/ogx.io_ogxservers.yaml
@@ -368,8 +368,9 @@ spec:
                         type: boolean
                       ingress:
                         description: |-
-                          Ingress defines additional ingress rules, merged with operator defaults
-                          (allow from same-namespace and operator-namespace on the service port).
+                          Ingress defines additional ingress rules, appended to the mandatory operator rules
+                          (allow from Praxis pods and the operator namespace on the service port). User rules
+                          are additive and cannot remove the mandatory Praxis lock-down.
                         items:
                           description: |-
                             NetworkPolicyIngressRule describes a particular set of traffic that is allowed to the pods

--- a/config/overlays/openshift/kustomization.yaml
+++ b/config/overlays/openshift/kustomization.yaml
@@ -20,9 +20,8 @@ patches:
       path: /metadata/annotations
       value:
         service.beta.openshift.io/serving-cert-secret-name: ogx-k8s-operator-webhook-cert
-# Annotate the ValidatingWebhookConfiguration and MutatingWebhookConfiguration
-# so OpenShift injects the service-ca CA bundle into
-# webhooks[].clientConfig.caBundle.
+# Annotate the ValidatingWebhookConfiguration so OpenShift injects the
+# service-ca CA bundle into webhooks[].clientConfig.caBundle.
 - target:
     kind: ValidatingWebhookConfiguration
   patch: |-
@@ -30,6 +29,8 @@ patches:
       path: /metadata/annotations
       value:
         service.beta.openshift.io/inject-cabundle: "true"
+# Annotate the MutatingWebhookConfiguration so OpenShift injects the
+# service-ca CA bundle into webhooks[].clientConfig.caBundle.
 - target:
     kind: MutatingWebhookConfiguration
   patch: |-

--- a/config/samples/example-with-network-config.yaml
+++ b/config/samples/example-with-network-config.yaml
@@ -1,4 +1,13 @@
-# Example with custom NetworkPolicy ingress rules (namespace-based access)
+# OGX in Praxis-fronted (internal-only) mode. When Praxis mode is enabled, the operator restricts
+# ingress on port 8321 to the Praxis pods identified by spec.praxisMode.praxisSelector (defaulting
+# to pods labeled app: payload-processing in the openshift-ingress namespace) plus the operator
+# namespace. The network.policy.ingress rules below are ADDITIVE: they are appended on top of that
+# mandatory lock-down and cannot remove it.
+#
+# spec.praxisMode.enabled is tri-state: true (force Praxis mode), false (force legacy mode), or
+# unset. New CRs get spec.praxisMode.enabled defaulted to true on create by the operator's mutating
+# webhook (greenfield -> Praxis mode); CRs predating the webhook keep an unset value and stay in
+# legacy mode.
 apiVersion: ogx.io/v1beta1
 kind: OGXServer
 metadata:
@@ -6,6 +15,17 @@ metadata:
 spec:
   distribution:
     name: starter
+  praxisMode:
+    enabled: true
+    # praxisSelector identifies the Praxis instance that fronts this OGXServer. It is honored as the
+    # NetworkPolicy ingress peer. When omitted, the operator falls back to pods labeled
+    # app: payload-processing in the openshift-ingress namespace. Set it per-CR so different
+    # OGXServers can migrate to different Praxis instances independently.
+    praxisSelector:
+      namespace: praxis
+      podSelector:
+        matchLabels:
+          app: payload-processing
   workload:
     overrides:
       env:
@@ -15,18 +35,12 @@ spec:
           value: 'http://ollama-server-service.ollama-dist.svc.cluster.local:11434'
   network:
     policy:
+      # These rules are added on top of the mandatory Praxis + operator ingress rules.
       ingress:
         - from:
             - namespaceSelector:
                 matchLabels:
                   kubernetes.io/metadata.name: nsA
-            - namespaceSelector:
-                matchLabels:
-                  kubernetes.io/metadata.name: nsB
-            - namespaceSelector:
-                matchExpressions:
-                  - key: myproject/ogx-allowed
-                    operator: Exists
             - namespaceSelector:
                 matchExpressions:
                   - key: team/authorized
@@ -35,14 +49,19 @@ spec:
             - protocol: TCP
               port: 8321
 ---
-# Example with external access enabled and NetworkPolicy disabled
+# NOTE: in Praxis mode (praxisMode.enabled: true) externalAccess.enabled is NOT honored — OGX is
+# internal-only. Setting it to true produces an admission warning and no external exposure
+# (Ingress) is created. In legacy mode (praxisMode.enabled: false) externalAccess.enabled is
+# honored and the operator creates an Ingress. This example documents the Praxis-mode behavior.
 apiVersion: ogx.io/v1beta1
 kind: OGXServer
 metadata:
-  name: ogxserver-public
+  name: ogxserver-external-access-ignored
 spec:
   distribution:
     name: starter
+  praxisMode:
+    enabled: true
   workload:
     overrides:
       env:
@@ -52,16 +71,9 @@ spec:
           value: 'http://ollama-server-service.ollama-dist.svc.cluster.local:11434'
   network:
     externalAccess:
-      enabled: true
-    policy:
-      ingress:
-        - from:
-            - namespaceSelector: {}
-          ports:
-            - protocol: TCP
-              port: 8321
+      enabled: true # ignored: treated as false, no Ingress created
 ---
-# Example with NetworkPolicy explicitly disabled
+# Example with NetworkPolicy explicitly disabled (emergency escape hatch).
 apiVersion: ogx.io/v1beta1
 kind: OGXServer
 metadata:

--- a/controllers/configmap_reconciler.go
+++ b/controllers/configmap_reconciler.go
@@ -77,7 +77,7 @@ func (r *OGXServerReconciler) reconcileGeneratedConfig(ctx context.Context, inst
 		return nil, fmt.Errorf("failed to validate secret env var mapping: %w", validateErr)
 	}
 
-	generated, err := config.GenerateConfig(&instance.Spec, baseConfigData)
+	generated, err := config.GenerateConfig(&instance.Spec, baseConfigData, r.resolvePraxisMode(instance))
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate config: %w", err)
 	}

--- a/controllers/network_resources.go
+++ b/controllers/network_resources.go
@@ -37,6 +37,21 @@ const (
 	IngressNameSuffix = "-ingress"
 )
 
+// resolvePraxisMode reports whether this instance runs in the internal-only, Praxis-fronted
+// posture. The mode is driven solely by spec.praxisMode.enabled:
+//   - enabled: true  → Praxis-fronted (internal-only).
+//   - enabled: false → legacy behavior.
+//   - spec.praxisMode or spec.praxisMode.enabled unset → legacy behavior.
+//
+// A brand-new (greenfield) CR gets spec.praxisMode.enabled defaulted to true by the mutating
+// admission webhook on create (see api/v1beta1/ogxserver_webhook.go). An unset value here therefore
+// means a CR created before the webhook existed (an operator upgrade) or one for which the webhook
+// did not run; both are treated as legacy so an upgrade never silently cuts off co-located workloads.
+func (r *OGXServerReconciler) resolvePraxisMode(instance *ogxiov1beta1.OGXServer) bool {
+	return instance.Spec.PraxisMode != nil &&
+		instance.Spec.PraxisMode.Enabled != nil && *instance.Spec.PraxisMode.Enabled
+}
+
 // buildIngress creates an Ingress for external access to the OGXServer.
 func (r *OGXServerReconciler) buildIngress(
 	instance *ogxiov1beta1.OGXServer,
@@ -87,8 +102,55 @@ func (r *OGXServerReconciler) buildIngress(
 	return ingress, nil
 }
 
-// reconcileIngress creates, updates, or deletes the Ingress based on expose setting.
+// reconcileIngress reconciles the Ingress according to the deployment mode. In Praxis mode OGX
+// is an internal backend reached only from Praxis, so external exposure is enforced off. In
+// legacy mode the Ingress is created/updated/deleted based on spec.network.externalAccess.
 func (r *OGXServerReconciler) reconcileIngress(
+	ctx context.Context,
+	instance *ogxiov1beta1.OGXServer,
+) error {
+	if r.resolvePraxisMode(instance) {
+		return r.enforceInternalOnlyIngress(ctx, instance)
+	}
+	return r.reconcileLegacyIngress(ctx, instance)
+}
+
+// enforceInternalOnlyIngress removes any operator-owned Ingress for this instance. In the
+// Praxis-fronted topology OGX is reached only from Praxis, so the operator never creates
+// external exposure. The operator only ever created Ingress resources for external access
+// (there is no OpenShift Route or Gateway API HTTPRoute to remove).
+func (r *OGXServerReconciler) enforceInternalOnlyIngress(
+	ctx context.Context,
+	instance *ogxiov1beta1.OGXServer,
+) error {
+	logger := log.FromContext(ctx)
+	ingressName := instance.Name + IngressNameSuffix
+
+	existing := &networkingv1.Ingress{}
+	if err := r.Get(ctx, types.NamespacedName{Name: ingressName, Namespace: instance.Namespace}, existing); err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to get Ingress: %w", err)
+	}
+
+	if !metav1.IsControlledBy(existing, instance) {
+		logger.V(1).Info("Ingress not owned by this instance, skipping deletion", "name", ingressName)
+		return nil
+	}
+
+	logger.Info("Deleting Ingress: OGX is internal-only (Praxis-fronted), external access is not exposed",
+		"name", ingressName)
+	if err := r.Delete(ctx, existing); err != nil && !k8serrors.IsNotFound(err) {
+		return fmt.Errorf("failed to delete Ingress: %w", err)
+	}
+
+	return nil
+}
+
+// reconcileLegacyIngress creates, updates, or deletes the Ingress based on the expose setting
+// (pre-Praxis behavior).
+func (r *OGXServerReconciler) reconcileLegacyIngress(
 	ctx context.Context,
 	instance *ogxiov1beta1.OGXServer,
 ) error {
@@ -229,4 +291,9 @@ func (r *OGXServerReconciler) BuildIngressForTest(
 	instance *ogxiov1beta1.OGXServer,
 ) (*networkingv1.Ingress, error) {
 	return r.buildIngress(instance)
+}
+
+// ReconcileIngressForTest exposes reconcileIngress for unit testing.
+func (r *OGXServerReconciler) ReconcileIngressForTest(ctx context.Context, instance *ogxiov1beta1.OGXServer) error {
+	return r.reconcileIngress(ctx, instance)
 }

--- a/controllers/network_resources_test.go
+++ b/controllers/network_resources_test.go
@@ -17,67 +17,41 @@ limitations under the License.
 package controllers_test
 
 import (
+	"context"
 	"testing"
 
 	ogxiov1beta1 "github.com/ogx-ai/ogx-k8s-operator/api/v1beta1"
 	"github.com/ogx-ai/ogx-k8s-operator/controllers"
 	"github.com/ogx-ai/ogx-k8s-operator/pkg/cluster"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	networkingv1 "k8s.io/api/networking/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-func TestBuildIngress(t *testing.T) {
+func newIngressTestReconciler(t *testing.T, objs ...client.Object) (*controllers.OGXServerReconciler, client.Client) {
+	t.Helper()
 	scheme := runtime.NewScheme()
 	require.NoError(t, ogxiov1beta1.AddToScheme(scheme))
+	require.NoError(t, networkingv1.AddToScheme(scheme))
 
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
 	clusterInfo := &cluster.ClusterInfo{
 		DistributionImages: map[string]string{"starter": "test-image:latest"},
 	}
-
-	reconciler := controllers.NewTestReconciler(nil, scheme, clusterInfo, nil)
-
-	instance := &ogxiov1beta1.OGXServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-ogx",
-			Namespace: "test-ns",
-			UID:       "test-uid",
-		},
-		Spec: ogxiov1beta1.OGXServerSpec{
-			Distribution: ogxiov1beta1.DistributionSpec{Name: "starter"},
-			Network: &ogxiov1beta1.NetworkSpec{
-				ExternalAccess: &ogxiov1beta1.ExternalAccessConfig{Enabled: true},
-			},
-		},
-	}
-
-	ingress, err := reconciler.BuildIngressForTest(instance)
-	require.NoError(t, err)
-	require.NotNil(t, ingress)
-
-	assert.Equal(t, "test-ogx-ingress", ingress.Name)
-	assert.Equal(t, "test-ns", ingress.Namespace)
-
-	require.Len(t, ingress.Spec.Rules, 1)
-	require.NotNil(t, ingress.Spec.Rules[0].HTTP)
-	require.Len(t, ingress.Spec.Rules[0].HTTP.Paths, 1)
-
-	assert.Equal(t, "test-ogx-service", ingress.Spec.Rules[0].HTTP.Paths[0].Backend.Service.Name)
-	assert.Equal(t, int32(8321), ingress.Spec.Rules[0].HTTP.Paths[0].Backend.Service.Port.Number)
+	return controllers.NewTestReconciler(c, scheme, clusterInfo, nil), c
 }
 
-func TestBuildIngress_CustomPort(t *testing.T) {
-	scheme := runtime.NewScheme()
-	require.NoError(t, ogxiov1beta1.AddToScheme(scheme))
-
-	clusterInfo := &cluster.ClusterInfo{
-		DistributionImages: map[string]string{"starter": "test-image:latest"},
-	}
-
-	reconciler := controllers.NewTestReconciler(nil, scheme, clusterInfo, nil)
-
-	instance := &ogxiov1beta1.OGXServer{
+func newInternalOnlyInstance() *ogxiov1beta1.OGXServer {
+	// A greenfield CR has spec.praxisMode.enabled defaulted to true by the mutating webhook; unit
+	// tests set it explicitly since the webhook does not run against the fake client.
+	praxisOn := true
+	return &ogxiov1beta1.OGXServer{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-ogx",
 			Namespace: "test-ns",
@@ -85,16 +59,119 @@ func TestBuildIngress_CustomPort(t *testing.T) {
 		},
 		Spec: ogxiov1beta1.OGXServerSpec{
 			Distribution: ogxiov1beta1.DistributionSpec{Name: "starter"},
+			PraxisMode:   &ogxiov1beta1.PraxisModeSpec{Enabled: &praxisOn},
+			// External access requested, but OGX is internal-only so it must not be honored.
 			Network: &ogxiov1beta1.NetworkSpec{
-				Port:           9000,
 				ExternalAccess: &ogxiov1beta1.ExternalAccessConfig{Enabled: true},
 			},
 		},
 	}
+}
 
-	ingress, err := reconciler.BuildIngressForTest(instance)
-	require.NoError(t, err)
-	require.NotNil(t, ingress)
+// TestReconcileIngress_DoesNotCreateWhenExternalAccessEnabled verifies OGX is enforced
+// internal-only: even with externalAccess.enabled=true, no Ingress is created.
+func TestReconcileIngress_DoesNotCreateWhenExternalAccessEnabled(t *testing.T) {
+	instance := newInternalOnlyInstance()
+	reconciler, c := newIngressTestReconciler(t)
 
-	assert.Equal(t, int32(9000), ingress.Spec.Rules[0].HTTP.Paths[0].Backend.Service.Port.Number)
+	require.NoError(t, reconciler.ReconcileIngressForTest(context.Background(), instance))
+
+	var ing networkingv1.Ingress
+	err := c.Get(context.Background(), types.NamespacedName{
+		Name:      instance.Name + controllers.IngressNameSuffix,
+		Namespace: instance.Namespace,
+	}, &ing)
+	require.True(t, apierrors.IsNotFound(err), "no Ingress should be created for an internal-only OGX")
+}
+
+// TestReconcileIngress_DeletesPreviouslyCreatedIngress verifies an operator-owned Ingress
+// left over from a prior (externally-exposed) deployment is removed on reconcile.
+func TestReconcileIngress_DeletesPreviouslyCreatedIngress(t *testing.T) {
+	instance := newInternalOnlyInstance()
+
+	existing := &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      instance.Name + controllers.IngressNameSuffix,
+			Namespace: instance.Namespace,
+		},
+	}
+	scheme := runtime.NewScheme()
+	require.NoError(t, ogxiov1beta1.AddToScheme(scheme))
+	require.NoError(t, networkingv1.AddToScheme(scheme))
+	require.NoError(t, ctrl.SetControllerReference(instance, existing, scheme))
+
+	reconciler, c := newIngressTestReconciler(t, existing)
+
+	require.NoError(t, reconciler.ReconcileIngressForTest(context.Background(), instance))
+
+	var ing networkingv1.Ingress
+	err := c.Get(context.Background(), types.NamespacedName{
+		Name:      existing.Name,
+		Namespace: existing.Namespace,
+	}, &ing)
+	require.True(t, apierrors.IsNotFound(err), "previously-created owned Ingress should be deleted")
+}
+
+// TestReconcileIngress_LegacyModeCreatesIngress verifies that with praxisMode explicitly
+// disabled the operator preserves the legacy behavior and creates an Ingress when external
+// access is enabled.
+func TestReconcileIngress_LegacyModeCreatesIngress(t *testing.T) {
+	instance := newInternalOnlyInstance()
+	legacy := false
+	instance.Spec.PraxisMode = &ogxiov1beta1.PraxisModeSpec{Enabled: &legacy}
+
+	reconciler, c := newIngressTestReconciler(t)
+
+	require.NoError(t, reconciler.ReconcileIngressForTest(context.Background(), instance))
+
+	var ing networkingv1.Ingress
+	err := c.Get(context.Background(), types.NamespacedName{
+		Name:      instance.Name + controllers.IngressNameSuffix,
+		Namespace: instance.Namespace,
+	}, &ing)
+	require.NoError(t, err, "legacy mode with externalAccess enabled should create an Ingress")
+}
+
+// TestReconcileIngress_UnsetModeDefaultsToLegacy verifies that an unset praxisMode resolves to
+// legacy mode. New CRs get praxisMode defaulted to true by the mutating webhook; a CR that reaches
+// the controller with an unset value predates the webhook (an upgrade) and must stay in legacy mode
+// so external access is not silently removed.
+func TestReconcileIngress_UnsetModeDefaultsToLegacy(t *testing.T) {
+	instance := newInternalOnlyInstance()
+	instance.Spec.PraxisMode = nil
+
+	reconciler, c := newIngressTestReconciler(t)
+
+	require.NoError(t, reconciler.ReconcileIngressForTest(context.Background(), instance))
+
+	var ing networkingv1.Ingress
+	err := c.Get(context.Background(), types.NamespacedName{
+		Name:      instance.Name + controllers.IngressNameSuffix,
+		Namespace: instance.Namespace,
+	}, &ing)
+	require.NoError(t, err, "an unset praxisMode should default to legacy mode and honor external access")
+}
+
+// TestReconcileIngress_LeavesUnownedIngress verifies the operator does not delete an Ingress
+// it does not own (no controller reference to this instance).
+func TestReconcileIngress_LeavesUnownedIngress(t *testing.T) {
+	instance := newInternalOnlyInstance()
+
+	unowned := &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      instance.Name + controllers.IngressNameSuffix,
+			Namespace: instance.Namespace,
+		},
+	}
+
+	reconciler, c := newIngressTestReconciler(t, unowned)
+
+	require.NoError(t, reconciler.ReconcileIngressForTest(context.Background(), instance))
+
+	var ing networkingv1.Ingress
+	err := c.Get(context.Background(), types.NamespacedName{
+		Name:      unowned.Name,
+		Namespace: unowned.Namespace,
+	}, &ing)
+	require.NoError(t, err, "an Ingress not owned by this instance must not be deleted")
 }

--- a/controllers/ogxserver_controller.go
+++ b/controllers/ogxserver_controller.go
@@ -573,6 +573,8 @@ func (r *OGXServerReconciler) buildManifestContext(
 		PodSpec:                 podSpecMap,
 		PodDisruptionBudgetSpec: buildPodDisruptionBudgetSpec(instance),
 		HPASpec:                 buildHPASpec(instance),
+		PraxisPeer:              BuildPraxisPeer(instance),
+		PraxisMode:              r.resolvePraxisMode(instance),
 	}, nil
 }
 
@@ -1297,12 +1299,19 @@ func (r *OGXServerReconciler) updateServiceStatus(ctx context.Context, instance 
 		return
 	}
 
-	// Set the service URL in the status
+	// Set the internal service URL in the status. This is the stable endpoint Praxis and
+	// the platform use to reach OGX.
 	serviceURL := r.getServerURL(instance, "")
 	instance.Status.ServiceURL = serviceURL.String()
 
-	// Set the external URL if external access is enabled
-	instance.Status.ExternalURL = r.getIngressURL(ctx, instance)
+	if r.resolvePraxisMode(instance) {
+		// OGX is internal-only (Praxis-fronted): no external exposure is created, so the
+		// external URL is always cleared.
+		instance.Status.ExternalURL = nil
+	} else {
+		// Legacy mode: reflect any operator-created external exposure.
+		instance.Status.ExternalURL = r.getIngressURL(ctx, instance)
+	}
 
 	SetServiceReadyCondition(&instance.Status, true, MessageServiceReady)
 }
@@ -1923,6 +1932,47 @@ func ParseImageMappingOverrides(ctx context.Context, configMapData map[string]st
 	}
 
 	return imageMappingOverrides
+}
+
+// BuildPraxisPeer returns the NetworkPolicy ingress peer identifying the Praxis instance that
+// fronts this OGXServer. When spec.praxisMode.praxisSelector is set it is honored (the selector's
+// namespace is matched via the well-known kubernetes.io/metadata.name label); otherwise the
+// fail-safe default peer is returned. It never returns nil. The praxisSelector's pod selector is
+// CEL-validated non-empty (see api/v1beta1), so this never produces an allow-all peer.
+func BuildPraxisPeer(instance *ogxiov1beta1.OGXServer) *networkingv1.NetworkPolicyPeer {
+	if instance.Spec.PraxisMode == nil || instance.Spec.PraxisMode.PraxisSelector == nil {
+		return defaultPraxisPeer()
+	}
+
+	sel := instance.Spec.PraxisMode.PraxisSelector
+	podSelector := sel.PodSelector
+	return &networkingv1.NetworkPolicyPeer{
+		PodSelector: &podSelector,
+		NamespaceSelector: &metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				ogxiov1beta1.DefaultNamespaceNameLabel: sel.Namespace,
+			},
+		},
+	}
+}
+
+// defaultPraxisPeer returns the fail-safe Praxis NetworkPolicy ingress peer: pods labeled
+// app: payload-processing in the openshift-ingress namespace. It is used when a CR does not set
+// spec.praxisMode.praxisSelector, and is never an allow-all peer. The namespace is provisional
+// (see ogxiov1beta1.DefaultPraxisNamespace) and can be overridden per-CR via praxisSelector.
+func defaultPraxisPeer() *networkingv1.NetworkPolicyPeer {
+	return &networkingv1.NetworkPolicyPeer{
+		PodSelector: &metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				ogxiov1beta1.DefaultLabelKey: ogxiov1beta1.DefaultPraxisPodLabelValue,
+			},
+		},
+		NamespaceSelector: &metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				ogxiov1beta1.DefaultNamespaceNameLabel: ogxiov1beta1.DefaultPraxisNamespace,
+			},
+		},
+	}
 }
 
 // NewTestReconciler creates a reconciler for testing, allowing injection of a custom http client.

--- a/controllers/ogxserver_controller_test.go
+++ b/controllers/ogxserver_controller_test.go
@@ -348,6 +348,7 @@ func TestReconcile(t *testing.T) {
 		WithNamespace(namespace.Name).
 		WithDistribution("starter").
 		WithPort(instancePort).
+		WithPraxisMode(true). // greenfield posture; webhook does not run in envtest
 		Build()
 	require.NoError(t, k8sClient.Create(t.Context(), instance))
 
@@ -966,6 +967,75 @@ onemore: registry.redhat.io/org/imagename@sha256:1234567890123456789012345678901
 		result["onemore"], "Valid onemore override should be present")
 	require.NotContains(t, result, "invalid", "Invalid entry should be skipped")
 	require.NotContains(t, result, "malformed", "Malformed entry should be skipped")
+}
+
+func praxisDefault() *networkingv1.NetworkPolicyPeer {
+	return &networkingv1.NetworkPolicyPeer{
+		PodSelector: &metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				ogxiov1beta1.DefaultLabelKey: ogxiov1beta1.DefaultPraxisPodLabelValue,
+			},
+		},
+		NamespaceSelector: &metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				ogxiov1beta1.DefaultNamespaceNameLabel: ogxiov1beta1.DefaultPraxisNamespace,
+			},
+		},
+	}
+}
+
+func TestBuildPraxisPeer(t *testing.T) {
+	tests := []struct {
+		name       string
+		praxisMode *ogxiov1beta1.PraxisModeSpec
+		want       *networkingv1.NetworkPolicyPeer
+	}{
+		{
+			name:       "unset praxisMode falls back to default peer",
+			praxisMode: nil,
+			want:       praxisDefault(),
+		},
+		{
+			name:       "praxisMode without praxisSelector falls back to default peer",
+			praxisMode: &ogxiov1beta1.PraxisModeSpec{},
+			want:       praxisDefault(),
+		},
+		{
+			name: "praxisSelector is honored (namespace matched by metadata.name label)",
+			praxisMode: &ogxiov1beta1.PraxisModeSpec{
+				PraxisSelector: &ogxiov1beta1.PraxisSelector{
+					Namespace:   "praxis-ns",
+					PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{"app": "custom-praxis"}},
+				},
+			},
+			want: &networkingv1.NetworkPolicyPeer{
+				PodSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"app": "custom-praxis"},
+				},
+				NamespaceSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"kubernetes.io/metadata.name": "praxis-ns"},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			instance := &ogxiov1beta1.OGXServer{Spec: ogxiov1beta1.OGXServerSpec{PraxisMode: tc.praxisMode}}
+			got := controllers.BuildPraxisPeer(instance)
+			require.NotNil(t, got, "BuildPraxisPeer must never return nil")
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestBuildPraxisPeer_DefaultNeverAllowAll(t *testing.T) {
+	peer := controllers.BuildPraxisPeer(&ogxiov1beta1.OGXServer{})
+	require.NotNil(t, peer.PodSelector)
+	require.Equal(t, ogxiov1beta1.DefaultPraxisPodLabelValue, peer.PodSelector.MatchLabels[ogxiov1beta1.DefaultLabelKey])
+	require.NotNil(t, peer.NamespaceSelector, "default peer should pin the Praxis namespace")
+	require.Equal(t, ogxiov1beta1.DefaultPraxisNamespace,
+		peer.NamespaceSelector.MatchLabels[ogxiov1beta1.DefaultNamespaceNameLabel])
 }
 
 func TestNewOGXServerReconciler_WithImageOverrides(t *testing.T) {

--- a/controllers/testing_support_test.go
+++ b/controllers/testing_support_test.go
@@ -100,6 +100,14 @@ func (b *OGXServerBuilder) WithDistribution(distributionName string) *OGXServerB
 	return b
 }
 
+// WithPraxisMode sets spec.praxisMode.enabled explicitly. In production the mutating webhook
+// defaults this to true on create for greenfield installs; envtest does not run the webhook, so
+// tests that need the Praxis-fronted posture set it explicitly.
+func (b *OGXServerBuilder) WithPraxisMode(enabled bool) *OGXServerBuilder {
+	b.instance.Spec.PraxisMode = &ogxiov1beta1.PraxisModeSpec{Enabled: &enabled}
+	return b
+}
+
 func (b *OGXServerBuilder) WithResources(resources corev1.ResourceRequirements) *OGXServerBuilder {
 	if b.instance.Spec.Workload == nil {
 		b.instance.Spec.Workload = &ogxiov1beta1.WorkloadSpec{}
@@ -368,12 +376,13 @@ func AssertNetworkPolicyAllowsDeploymentPort(t *testing.T, networkPolicy *networ
 	require.NotEmpty(t, deployment.Spec.Template.Spec.Containers[0].Ports, "Container should have at least one port")
 	containerPort := deployment.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort
 
-	sameNamespacePredicate := func(peer networkingv1.NetworkPolicyPeer) bool {
-		return peer.PodSelector != nil && len(peer.PodSelector.MatchLabels) == 0 && peer.NamespaceSelector == nil
+	praxisPredicate := func(peer networkingv1.NetworkPolicyPeer) bool {
+		return peer.PodSelector != nil &&
+			peer.PodSelector.MatchLabels[ogxiov1beta1.DefaultLabelKey] == ogxiov1beta1.DefaultPraxisPodLabelValue
 	}
 	require.True(t,
-		hasMatchingIngressRule(t, networkPolicy, containerPort, sameNamespacePredicate),
-		"NetworkPolicy is missing a rule to allow traffic from all pods in the same namespace on port %d", containerPort)
+		hasMatchingIngressRule(t, networkPolicy, containerPort, praxisPredicate),
+		"NetworkPolicy is missing a rule to allow traffic from Praxis pods on port %d", containerPort)
 
 	operatorPredicate := func(peer networkingv1.NetworkPolicyPeer) bool {
 		return peer.NamespaceSelector != nil && peer.NamespaceSelector.MatchLabels["kubernetes.io/metadata.name"] == operatorNamespace
@@ -381,6 +390,14 @@ func AssertNetworkPolicyAllowsDeploymentPort(t *testing.T, networkPolicy *networ
 	require.True(t,
 		hasMatchingIngressRule(t, networkPolicy, containerPort, operatorPredicate),
 		"NetworkPolicy is missing a rule to allow traffic from the operator in namespace '%s' on port %d", operatorNamespace, containerPort)
+
+	sameNamespacePredicate := func(peer networkingv1.NetworkPolicyPeer) bool {
+		return peer.PodSelector != nil && len(peer.PodSelector.MatchLabels) == 0 &&
+			len(peer.PodSelector.MatchExpressions) == 0 && peer.NamespaceSelector == nil
+	}
+	require.False(t,
+		hasMatchingIngressRule(t, networkPolicy, containerPort, sameNamespacePredicate),
+		"NetworkPolicy must NOT allow traffic from all pods in the same namespace on port %d", containerPort)
 }
 
 func AssertNetworkPolicyIsIngressOnly(t *testing.T, networkPolicy *networkingv1.NetworkPolicy) {

--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -859,15 +859,12 @@ _Appears in:_
 
 NetworkPolicySpec configures the operator-managed NetworkPolicy for this server.
 
-Ingress is always enforced unless explicitly omitted from policyTypes.
-The operator always includes default ingress rules (allow from same-namespace
-and operator-namespace on the service port), merging them with any
-user-specified rules.
+The operator always enforces a mandatory ingress lock-down: OGX accepts traffic on the
+service port only from Praxis pods (the internal API front-end) plus the operator
+namespace (control-plane status polling). These mandatory rules cannot be removed via this
+spec; set Enabled=false to disable the NetworkPolicy entirely as an escape hatch.
 
-Egress is unrestricted by default. It is only enforced when egress rules
-are provided or "Egress" is explicitly included in policyTypes.
-When any egress rules are configured, or when "Egress" is explicitly included in
-policyTypes, a kube-dns egress rule is auto-injected to prevent DNS breakage.
+Egress is unrestricted by default. It is only enforced when egress rules are provided.
 
 _Appears in:_
 - [NetworkSpec](#networkspec)
@@ -876,7 +873,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `enabled` _boolean_ | Enabled controls whether the operator manages a NetworkPolicy for this server.<br />Defaults to true. Set to false to disable NetworkPolicy creation entirely. | true |  |
 | `policyTypes` _[PolicyType](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#policytype-v1-networking) array_ | PolicyTypes specifies which policy directions are enforced.<br />Follows Kubernetes NetworkPolicy semantics: when omitted or empty,<br />Ingress is always included and Egress is included only if egress<br />rules are provided. |  | items:Enum: [Ingress Egress] <br /> |
-| `ingress` _[NetworkPolicyIngressRule](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#networkpolicyingressrule-v1-networking) array_ | Ingress defines additional ingress rules, merged with operator defaults<br />(allow from same-namespace and operator-namespace on the service port). |  |  |
+| `ingress` _[NetworkPolicyIngressRule](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#networkpolicyingressrule-v1-networking) array_ | Ingress defines additional ingress rules, appended to the mandatory operator rules<br />(allow from Praxis pods and the operator namespace on the service port). User rules<br />are additive and cannot remove the mandatory Praxis lock-down. |  |  |
 | `egress` _[NetworkPolicyEgressRule](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#networkpolicyegressrule-v1-networking) array_ | Egress rules. When non-empty, a kube-dns egress rule is auto-injected<br />to prevent DNS breakage. |  |  |
 
 #### NetworkSpec

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -183,6 +183,52 @@ spec:
 
 To translate `enableNetworkPolicy: false` from the old ConfigMap, set `spec.network.policy.enabled: false` on the CR.
 
+#### Internal-only enforcement (Praxis-fronted)
+
+OGX is an **internal-only backend**: it is fronted by Praxis, which is the sole public
+entrypoint. The operator can enforce this via **Praxis-fronted mode** (`spec.praxisMode`, whose
+API is introduced by [#355](https://github.com/ogx-ai/ogx-k8s-operator/pull/355) / RHAIENG-7193).
+
+**Mode selection (upgrade-safe):** `spec.praxisMode.enabled` is tri-state — `true` (force Praxis
+mode), `false` (force legacy mode), or unset. New CRs get `spec.praxisMode.enabled` defaulted to
+`true` on create by the operator's **mutating admission webhook**, so greenfield installs adopt
+Praxis mode. A CR created before the webhook existed (i.e. across an operator upgrade) keeps an
+unset value, which is treated as **legacy mode**, so upgrading the operator does **not** silently
+change behavior. To adopt the internal-only posture on an existing install, set
+`spec.praxisMode.enabled: true` explicitly; because the switch is per-CR, OGXServers can migrate
+independently.
+
+When Praxis mode is active, it is a **breaking change** relative to legacy behavior on clusters
+with a policy-enforcing CNI (OVN-Kubernetes / Calico):
+
+- The default NetworkPolicy ingress on port `8321` admits traffic **only** from the Praxis pods
+  identified by `spec.praxisMode.praxisSelector` (defaulting to label `app: payload-processing`)
+  and the operator namespace. The previous "allow all pods in the same namespace" and
+  OpenShift-router rules are removed. Co-located workloads that reached OGX directly will lose
+  access.
+- `spec.network.policy.ingress` rules are now **additive** — appended on top of the mandatory
+  Praxis + operator rules — and can no longer replace/remove them.
+- `spec.network.externalAccess.enabled: true` is **not honored**: it is treated as `false`
+  (surfaced as an admission warning, not a rejection), and any operator-created Ingress is
+  removed. `status.externalURL` is cleared; `status.serviceURL` continues to hold the internal
+  cluster DNS endpoint.
+- The **Responses API** is disabled in OGX's generated config (Praxis serves it). This is applied
+  internally during config generation and does **not** mutate your CR's `spec.disabledAPIs`.
+
+Escape hatches: set the Praxis selector per-CR via `spec.praxisMode.praxisSelector` (see the
+README); add per-CR additive `spec.network.policy.ingress` rules; or disable the policy entirely
+with `spec.network.policy.enabled: false`.
+
+> **Note (Praxis namespace):** the fail-safe default Praxis peer pins the `openshift-ingress`
+> namespace (where the PoC operator runs the Praxis/extproc servers). This is **provisional and
+> pending confirmation with the MaaS team**; if Praxis runs elsewhere, set the correct `namespace`
+> in `spec.praxisMode.praxisSelector`.
+
+> **Validated assumption (RHAISTRAT-2277):** OGX can be restricted to internal-only access via
+> NetworkPolicy without changes to the OGX Distribution (the Praxis selector is configured per-CR
+> via `spec.praxisMode.praxisSelector`). Enforcement is only effective on a policy-enforcing CNI;
+> on non-enforcing CNIs (e.g. kind's kindnet) the policy object exists but traffic is not blocked.
+
 ### ConfigMap/Secret Watch Labels and Namespace Scope
 
 All referenced ConfigMaps and Secrets must have the `ogx.io/watch: "true"` label, and must be in the same namespace as the OGXServer CR:

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -724,7 +724,7 @@ vector_stores:
 		},
 	}
 
-	generated, err := GenerateConfig(spec, []byte(baseConfig))
+	generated, err := GenerateConfig(spec, []byte(baseConfig), false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -772,7 +772,7 @@ providers:
 		DisabledAPIs: []string{"vector_io", "tool_runtime"},
 	}
 
-	generated, err := GenerateConfig(spec, []byte(baseConfig))
+	generated, err := GenerateConfig(spec, []byte(baseConfig), false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -792,13 +792,82 @@ apis:
 		DisabledAPIs: []string{"inference"},
 	}
 
-	generated, err := GenerateConfig(spec, []byte(baseConfig))
+	generated, err := GenerateConfig(spec, []byte(baseConfig), false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
 	if strings.Contains(generated.ConfigYAML, "apis:") {
 		t.Errorf("expected apis section to be removed when all APIs are disabled, got:\n%s", generated.ConfigYAML)
+	}
+}
+
+func TestGenerateConfig_PraxisModeDisablesResponses(t *testing.T) {
+	baseConfig := `version: '2'
+apis:
+- inference
+- responses
+- vector_io
+`
+
+	spec := &ogxiov1beta1.OGXServerSpec{}
+
+	generated, err := GenerateConfig(spec, []byte(baseConfig), true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if strings.Contains(generated.ConfigYAML, "- responses") {
+		t.Errorf("expected Praxis mode to disable the responses API, got:\n%s", generated.ConfigYAML)
+	}
+	if !strings.Contains(generated.ConfigYAML, "- inference") {
+		t.Errorf("expected other APIs to be preserved in Praxis mode, got:\n%s", generated.ConfigYAML)
+	}
+	// The user's spec must not be mutated by the internal disable.
+	if len(spec.DisabledAPIs) != 0 {
+		t.Errorf("expected spec.DisabledAPIs to be left untouched, got %v", spec.DisabledAPIs)
+	}
+}
+
+func TestGenerateConfig_LegacyModeKeepsResponses(t *testing.T) {
+	baseConfig := `version: '2'
+apis:
+- inference
+- responses
+`
+
+	spec := &ogxiov1beta1.OGXServerSpec{}
+
+	generated, err := GenerateConfig(spec, []byte(baseConfig), false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(generated.ConfigYAML, "- responses") {
+		t.Errorf("expected legacy mode to keep the responses API, got:\n%s", generated.ConfigYAML)
+	}
+}
+
+func TestGenerateConfig_PraxisModeResponsesAlreadyDisabled(t *testing.T) {
+	baseConfig := `version: '2'
+apis:
+- inference
+- responses
+`
+
+	// The user already disabled responses; Praxis mode must not duplicate it.
+	spec := &ogxiov1beta1.OGXServerSpec{DisabledAPIs: []string{"responses"}}
+
+	generated, err := GenerateConfig(spec, []byte(baseConfig), true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if strings.Contains(generated.ConfigYAML, "- responses") {
+		t.Errorf("expected responses API to be disabled, got:\n%s", generated.ConfigYAML)
+	}
+	if len(spec.DisabledAPIs) != 1 {
+		t.Errorf("expected spec.DisabledAPIs to be left untouched, got %v", spec.DisabledAPIs)
 	}
 }
 
@@ -814,11 +883,11 @@ providers:
 		DisabledAPIs: []string{"vector_io"},
 	}
 
-	g1, err := GenerateConfig(spec, []byte(baseConfig))
+	g1, err := GenerateConfig(spec, []byte(baseConfig), false)
 	if err != nil {
 		t.Fatal(err)
 	}
-	g2, err := GenerateConfig(spec, []byte(baseConfig))
+	g2, err := GenerateConfig(spec, []byte(baseConfig), false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1812,7 +1881,7 @@ providers:
 		},
 	}
 
-	generated, err := GenerateConfig(spec, []byte(baseConfig))
+	generated, err := GenerateConfig(spec, []byte(baseConfig), false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/config/generator.go
+++ b/pkg/config/generator.go
@@ -26,10 +26,16 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// responsesAPI is the name of the Responses API in the config's apis list. In Praxis-fronted mode
+// the Responses API is served by Praxis, so the operator disables it in OGX's generated config.
+const responsesAPI = "responses"
+
 // GenerateConfig orchestrates the config generation pipeline.
-// It takes the OGXServer spec and resolved base config, producing a
-// complete config.yaml with all provider/resource/storage expansions applied.
-func GenerateConfig(spec *ogxiov1beta1.OGXServerSpec, baseConfigData []byte) (*GeneratedConfig, error) {
+// It takes the OGXServer spec, the resolved base config, and whether the instance runs in
+// Praxis-fronted mode, producing a complete config.yaml with all provider/resource/storage
+// expansions applied. When praxisMode is true the Responses API is disabled in the generated
+// config (Praxis serves it) without mutating the user's CR.
+func GenerateConfig(spec *ogxiov1beta1.OGXServerSpec, baseConfigData []byte, praxisMode bool) (*GeneratedConfig, error) {
 	// Parse base config
 	baseConfig, err := ParseBaseConfig(baseConfigData)
 	if err != nil {
@@ -55,8 +61,14 @@ func GenerateConfig(spec *ogxiov1beta1.OGXServerSpec, baseConfigData []byte) (*G
 	userStorage := ApplyStorage(spec.Storage)
 	mergedStorage := MergeStorage(baseConfig.Storage, userStorage)
 
-	// Determine APIs (filter disabled)
-	mergedAPIs := MergeAPIs(baseConfig.APIs, spec.DisabledAPIs)
+	// Determine APIs (filter disabled). In Praxis-fronted mode the Responses API is served by
+	// Praxis, so it is disabled here internally — this augments spec.DisabledAPIs rather than
+	// mutating the user's CR.
+	disabledAPIs := spec.DisabledAPIs
+	if praxisMode {
+		disabledAPIs = appendIfMissing(disabledAPIs, responsesAPI)
+	}
+	mergedAPIs := MergeAPIs(baseConfig.APIs, disabledAPIs)
 
 	// Build the final config.yaml structure
 	finalConfig := buildFinalConfig(baseConfig, mergedProviders, userModels, mergedStorage, mergedAPIs, spec)
@@ -90,6 +102,19 @@ func GenerateConfig(spec *ogxiov1beta1.OGXServerSpec, baseConfigData []byte) (*G
 		ConfigVersion:          configVersion,
 		ConfigVersionDefaulted: !configVersionParsed,
 	}, nil
+}
+
+// appendIfMissing returns items with value appended, unless it is already present. The input slice
+// is not mutated (a fresh slice is returned when appending) so the caller's spec is left untouched.
+func appendIfMissing(items []string, value string) []string {
+	for _, item := range items {
+		if item == value {
+			return items
+		}
+	}
+	out := make([]string, len(items), len(items)+1)
+	copy(out, items)
+	return append(out, value)
 }
 
 func buildFinalConfig(

--- a/pkg/deploy/kustomizer.go
+++ b/pkg/deploy/kustomizer.go
@@ -15,6 +15,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -42,6 +43,8 @@ func RenderManifest(
 	fs filesys.FileSystem,
 	manifestPath string,
 	ownerInstance *ogxiov1beta1.OGXServer,
+	praxisPeer *networkingv1.NetworkPolicyPeer,
+	praxisMode bool,
 ) (*resmap.ResMap, error) {
 	// fallback to the 'default' directory' if we cannot initially find
 	// the kustomization file
@@ -56,7 +59,7 @@ func RenderManifest(
 	if err != nil {
 		return nil, fmt.Errorf("failed to run kustomize: %w", err)
 	}
-	if err := applyPlugins(&resMapVal, ownerInstance); err != nil {
+	if err := applyPlugins(&resMapVal, ownerInstance, praxisPeer, praxisMode); err != nil {
 		return nil, err
 	}
 	return &resMapVal, nil
@@ -219,7 +222,8 @@ func patchResource(ctx context.Context, cli client.Client, desired, existing *un
 }
 
 // applyPlugins runs all Go-based transformations on the resource map.
-func applyPlugins(resMap *resmap.ResMap, ownerInstance *ogxiov1beta1.OGXServer) error {
+func applyPlugins(resMap *resmap.ResMap, ownerInstance *ogxiov1beta1.OGXServer,
+	praxisPeer *networkingv1.NetworkPolicyPeer, praxisMode bool) error {
 	namePrefixPlugin := plugins.CreateNamePrefixPlugin(plugins.NamePrefixConfig{
 		Prefix: ownerInstance.GetName(),
 		// Exclude Deployment to maintain backward compatibility with existing deployment names
@@ -245,7 +249,7 @@ func applyPlugins(resMap *resmap.ResMap, ownerInstance *ogxiov1beta1.OGXServer) 
 	}
 
 	// Apply NetworkPolicy transformer to configure ingress rules based on spec.network
-	if err := applyNetworkPolicyTransformer(resMap, ownerInstance); err != nil {
+	if err := applyNetworkPolicyTransformer(resMap, ownerInstance, praxisPeer, praxisMode); err != nil {
 		return fmt.Errorf("failed to apply NetworkPolicy transformer: %w", err)
 	}
 
@@ -263,7 +267,8 @@ func applyPlugins(resMap *resmap.ResMap, ownerInstance *ogxiov1beta1.OGXServer) 
 }
 
 // applyNetworkPolicyTransformer applies the NetworkPolicy transformer plugin.
-func applyNetworkPolicyTransformer(resMap *resmap.ResMap, ownerInstance *ogxiov1beta1.OGXServer) error {
+func applyNetworkPolicyTransformer(resMap *resmap.ResMap, ownerInstance *ogxiov1beta1.OGXServer,
+	praxisPeer *networkingv1.NetworkPolicyPeer, praxisMode bool) error {
 	operatorNS, err := GetOperatorNamespace()
 	if err != nil {
 		operatorNS = "ogx-k8s-operator-system"
@@ -275,6 +280,8 @@ func applyNetworkPolicyTransformer(resMap *resmap.ResMap, ownerInstance *ogxiov1
 		OperatorNamespace: operatorNS,
 		NetworkSpec:       ownerInstance.Spec.Network,
 		MetricsPort:       getEffectiveMetricsPort(ownerInstance),
+		PraxisPeer:        praxisPeer,
+		PraxisMode:        praxisMode,
 	})
 
 	return npTransformer.Transform(*resMap)
@@ -472,6 +479,31 @@ type ManifestContext struct {
 	PodSpec                 map[string]any
 	PodDisruptionBudgetSpec *policyv1.PodDisruptionBudgetSpec
 	HPASpec                 *autoscalingv2.HorizontalPodAutoscalerSpec
+	// PraxisPeer is the NetworkPolicy ingress peer identifying Praxis pods. When nil,
+	// the NetworkPolicy transformer falls back to the default Praxis peer.
+	PraxisPeer *networkingv1.NetworkPolicyPeer
+	// PraxisMode selects the internal-only, Praxis-fronted posture for NetworkPolicy and
+	// external exposure. Resolved per-instance by the controller (see resolvePraxisMode).
+	PraxisMode bool
+}
+
+// praxisPeerFromContext returns the Praxis NetworkPolicy peer from the manifest context, or
+// nil when no context is provided (the transformer then applies its fail-safe default).
+func praxisPeerFromContext(manifestCtx *ManifestContext) *networkingv1.NetworkPolicyPeer {
+	if manifestCtx == nil {
+		return nil
+	}
+	return manifestCtx.PraxisPeer
+}
+
+// praxisModeFromContext returns the resolved Praxis mode from the manifest context. It defaults
+// to true (the internal-only target posture) when no context is provided, so low-level renders
+// without a controller-resolved mode still produce the locked-down NetworkPolicy.
+func praxisModeFromContext(manifestCtx *ManifestContext) bool {
+	if manifestCtx == nil {
+		return true
+	}
+	return manifestCtx.PraxisMode
 }
 
 // RenderManifestWithContext renders manifests and enhances the Deployment with complex specs.
@@ -482,7 +514,8 @@ func RenderManifestWithContext(
 	manifestCtx *ManifestContext,
 ) (*resmap.ResMap, error) {
 	// First, render the base manifests
-	resMap, err := RenderManifest(fs, manifestsPath, ownerInstance)
+	resMap, err := RenderManifest(fs, manifestsPath, ownerInstance,
+		praxisPeerFromContext(manifestCtx), praxisModeFromContext(manifestCtx))
 	if err != nil {
 		return nil, fmt.Errorf("failed to render base manifests: %w", err)
 	}

--- a/pkg/deploy/kustomizer_test.go
+++ b/pkg/deploy/kustomizer_test.go
@@ -112,7 +112,7 @@ spec:
 		}
 
 		// when we call RenderManifest
-		resMap, err := RenderManifest(fsys, manifestBasePath, owner)
+		resMap, err := RenderManifest(fsys, manifestBasePath, owner, nil, true)
 
 		// then we expect the resource to be rendered and transformed correctly
 		require.NoError(t, err)
@@ -161,7 +161,7 @@ metadata:
 		}
 
 		// when we call RenderManifest on the root path
-		resMap, err := RenderManifest(fsys, manifestBasePath, owner)
+		resMap, err := RenderManifest(fsys, manifestBasePath, owner, nil, true)
 
 		// then it should find and render the resources from the 'default' subdirectory
 		require.NoError(t, err)
@@ -211,7 +211,7 @@ spec:
 			},
 		}
 
-		resMap, err := RenderManifest(fsys, manifestBasePath, owner)
+		resMap, err := RenderManifest(fsys, manifestBasePath, owner, nil, true)
 		require.NoError(t, err)
 		require.Equal(t, 1, (*resMap).Size())
 
@@ -262,7 +262,7 @@ spec:
 			},
 		}
 
-		resMap, err := RenderManifest(fsys, manifestBasePath, owner)
+		resMap, err := RenderManifest(fsys, manifestBasePath, owner, nil, true)
 		require.NoError(t, err)
 		require.Equal(t, 1, (*resMap).Size())
 
@@ -303,7 +303,7 @@ resources:
 		}
 
 		// when we call RenderManifest
-		resMap, err := RenderManifest(fsys, manifestBasePath, owner)
+		resMap, err := RenderManifest(fsys, manifestBasePath, owner, nil, true)
 
 		// then it should propagate the error from the Kustomize engine
 		require.Error(t, err)
@@ -743,7 +743,7 @@ func TestRemoveDeploymentReplicas(t *testing.T) {
 	})))
 	require.NoError(t, resMap.Append(newTestResource(t, "apps/v1", "Deployment", "deployment-no-replicas", "llama", map[string]any{})))
 
-	require.NoError(t, applyPlugins(&resMap, instance))
+	require.NoError(t, applyPlugins(&resMap, instance, nil, true))
 
 	resources := resMap.Resources()
 	require.Len(t, resources, 2)

--- a/pkg/deploy/plugins/networkpolicy_transformer.go
+++ b/pkg/deploy/plugins/networkpolicy_transformer.go
@@ -23,6 +23,7 @@ import (
 
 	ogxiov1beta1 "github.com/ogx-ai/ogx-k8s-operator/api/v1beta1"
 	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/kustomize/api/resmap"
 	"sigs.k8s.io/kustomize/api/resource"
 	"sigs.k8s.io/yaml"
@@ -32,7 +33,7 @@ const (
 	networkPolicyKind = "NetworkPolicy"
 	// AllNamespacesSelector is the special value to allow all namespaces.
 	AllNamespacesSelector = "*"
-	// Allow traffic from OpenShift router namespaces.
+	// Allow traffic from OpenShift router (ingress) and monitoring namespaces.
 	openShiftIngressPolicyGroupLabelKey   = "network.openshift.io/policy-group"
 	openShiftIngressPolicyGroupLabelValue = "ingress"
 	openShiftMonitoringPolicyGroupValue   = "monitoring"
@@ -50,6 +51,16 @@ type NetworkPolicyTransformerConfig struct {
 	NetworkSpec *ogxiov1beta1.NetworkSpec
 	// MetricsPort is the port for Prometheus scraping. 0 means monitoring is disabled.
 	MetricsPort int32
+	// PraxisPeer is the ingress peer identifying Praxis pods, the only application
+	// workload allowed to reach OGX on the service port. When nil, a fail-safe default
+	// peer (pods labeled app: payload-processing in the openshift-ingress namespace) is used.
+	PraxisPeer *networkingv1.NetworkPolicyPeer
+	// PraxisMode selects the internal-only, Praxis-fronted ingress posture. When true,
+	// ingress is restricted to the Praxis peer plus the operator namespace and user rules
+	// are appended additively. When false, the legacy behavior is preserved: same-namespace
+	// and OpenShift-router peers, with user-provided ingress rules fully replacing the
+	// defaults.
+	PraxisMode bool
 }
 
 // CreateNetworkPolicyTransformer creates a transformer for NetworkPolicy resources.
@@ -103,8 +114,55 @@ func (t *networkPolicyTransformer) transformNetworkPolicy(res *resource.Resource
 	return updateResource(res, data)
 }
 
-// applyNetworkPolicySpec sets ingress/egress from the CR when explicitly provided; otherwise uses defaults.
+// applyNetworkPolicySpec configures the ingress/egress rules. The behavior depends on the
+// deployment mode:
+//   - Praxis mode: the mandatory Praxis + operator peers (plus monitoring) are always applied,
+//     and any user-provided ingress rules are appended additively so a CR author cannot remove
+//     the Praxis lock-down.
+//   - Legacy mode: user-provided ingress rules fully replace the defaults (the pre-Praxis
+//     behavior); otherwise the default same-namespace + operator + router peers are applied.
 func (t *networkPolicyTransformer) applyNetworkPolicySpec(spec map[string]any) error {
+	if !t.config.PraxisMode {
+		return t.applyLegacyNetworkPolicySpec(spec)
+	}
+	return t.applyPraxisNetworkPolicySpec(spec)
+}
+
+// applyPraxisNetworkPolicySpec applies the mandatory Praxis + operator peers (plus monitoring)
+// and appends any user-provided ingress rules additively.
+func (t *networkPolicyTransformer) applyPraxisNetworkPolicySpec(spec map[string]any) error {
+	ingressRules, err := t.buildIngressRules()
+	if err != nil {
+		return err
+	}
+
+	np := t.config.NetworkSpec
+	hasPolicy := np != nil && np.Policy != nil
+
+	if hasPolicy && len(np.Policy.Ingress) > 0 {
+		userIngress, convErr := networkPolicyRulesToAnySlice(np.Policy.Ingress)
+		if convErr != nil {
+			return fmt.Errorf("failed to convert NetworkPolicy ingress rules: %w", convErr)
+		}
+		ingressRules = append(ingressRules, userIngress...)
+	}
+	spec["ingress"] = ingressRules
+
+	if hasPolicy && len(np.Policy.Egress) > 0 {
+		egress, convErr := networkPolicyEgressRulesToAnySlice(np.Policy.Egress)
+		if convErr != nil {
+			return fmt.Errorf("failed to convert NetworkPolicy egress rules: %w", convErr)
+		}
+		spec["egress"] = egress
+		spec["policyTypes"] = []any{"Ingress", "Egress"}
+	}
+
+	return nil
+}
+
+// applyLegacyNetworkPolicySpec preserves the pre-Praxis behavior: user-provided ingress rules
+// replace the defaults (along with any egress), otherwise the default peer set is used.
+func (t *networkPolicyTransformer) applyLegacyNetworkPolicySpec(spec map[string]any) error {
 	np := t.config.NetworkSpec
 	if np != nil && np.Policy != nil && len(np.Policy.Ingress) > 0 {
 		ingress, err := networkPolicyRulesToAnySlice(np.Policy.Ingress)
@@ -125,7 +183,10 @@ func (t *networkPolicyTransformer) applyNetworkPolicySpec(spec map[string]any) e
 		return nil
 	}
 
-	ingressRules := t.buildIngressRules()
+	ingressRules, err := t.buildIngressRules()
+	if err != nil {
+		return err
+	}
 	spec["ingress"] = ingressRules
 	return nil
 }
@@ -173,8 +234,11 @@ func (t *networkPolicyTransformer) updatePodSelector(spec map[string]any) error 
 	return nil
 }
 
-func (t *networkPolicyTransformer) buildIngressRules() []any {
-	peers := t.buildPeers()
+func (t *networkPolicyTransformer) buildIngressRules() ([]any, error) {
+	peers, err := t.buildPeers()
+	if err != nil {
+		return nil, err
+	}
 
 	portRule := []any{
 		map[string]any{
@@ -190,36 +254,64 @@ func (t *networkPolicyTransformer) buildIngressRules() []any {
 		"ports": portRule,
 	})
 	rules = append(rules, monitoringRules...)
-	return rules
+	return rules, nil
 }
 
-func (t *networkPolicyTransformer) buildPeers() []any {
-	peers := t.buildDefaultPeers()
-	peers = append(peers, t.buildRouterPeers()...)
-	return peers
+// buildPeers builds the ingress peers for OGX.
+//
+// In Praxis mode the peers are:
+//  1. Praxis pods — the only application workload allowed to reach OGX on the service port.
+//  2. All pods from the operator namespace — control-plane traffic so the operator can poll
+//     OGX status (/v1/providers, /v1/version), not application traffic.
+//
+// The broad same-namespace peer and the OpenShift router peer are intentionally omitted so
+// OGX is reachable only from Praxis. In legacy mode those peers are retained (pre-Praxis
+// behavior).
+func (t *networkPolicyTransformer) buildPeers() ([]any, error) {
+	if !t.config.PraxisMode {
+		peers := t.buildDefaultPeers()
+		peers = append(peers, t.buildRouterPeers()...)
+		return peers, nil
+	}
+
+	praxisPeer, err := t.praxisPeerMap()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build Praxis NetworkPolicy peer: %w", err)
+	}
+
+	return []any{
+		praxisPeer,
+		t.operatorNamespacePeer(),
+	}, nil
 }
 
-// buildDefaultPeers builds the default NetworkPolicy peers:
-// 1. All pods within the same namespace (no pod-level restriction).
-// 2. All pods from the operator namespace.
+// operatorNamespacePeer allows ingress from all pods in the operator namespace so the operator
+// can poll OGX status endpoints.
+func (t *networkPolicyTransformer) operatorNamespacePeer() map[string]any {
+	return map[string]any{
+		"namespaceSelector": map[string]any{
+			"matchLabels": map[string]any{
+				"kubernetes.io/metadata.name": t.config.OperatorNamespace,
+			},
+		},
+	}
+}
+
+// buildDefaultPeers builds the legacy (pre-Praxis) NetworkPolicy peers:
+//  1. All pods within the same namespace (no pod-level restriction).
+//  2. All pods from the operator namespace.
 func (t *networkPolicyTransformer) buildDefaultPeers() []any {
 	return []any{
 		// Allow from all pods in the same namespace
 		map[string]any{
 			"podSelector": map[string]any{},
 		},
-		// Allow from operator namespace (no podSelector to allow all pods in the namespace)
-		map[string]any{
-			"namespaceSelector": map[string]any{
-				"matchLabels": map[string]any{
-					"kubernetes.io/metadata.name": t.config.OperatorNamespace,
-				},
-			},
-		},
+		t.operatorNamespacePeer(),
 	}
 }
 
-// buildRouterPeers builds NetworkPolicy peers for ingress controller traffic.
+// buildRouterPeers builds legacy NetworkPolicy peers for OpenShift ingress-controller traffic.
+// Only applied in legacy mode when network configuration is present.
 func (t *networkPolicyTransformer) buildRouterPeers() []any {
 	if t.config.NetworkSpec == nil {
 		return nil
@@ -235,6 +327,37 @@ func (t *networkPolicyTransformer) buildRouterPeers() []any {
 			},
 		},
 	}
+}
+
+// praxisPeerMap returns the configured Praxis peer as a generic map for the ingress rule,
+// falling back to the default peer (pods labeled app: payload-processing in the
+// openshift-ingress namespace) when none is configured.
+func (t *networkPolicyTransformer) praxisPeerMap() (map[string]any, error) {
+	peer := t.config.PraxisPeer
+	if peer == nil {
+		peer = &networkingv1.NetworkPolicyPeer{
+			PodSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					ogxiov1beta1.DefaultLabelKey: ogxiov1beta1.DefaultPraxisPodLabelValue,
+				},
+			},
+			NamespaceSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					ogxiov1beta1.DefaultNamespaceNameLabel: ogxiov1beta1.DefaultPraxisNamespace,
+				},
+			},
+		}
+	}
+
+	b, err := json.Marshal(peer)
+	if err != nil {
+		return nil, err
+	}
+	var out map[string]any
+	if err := json.Unmarshal(b, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 // buildMonitoringIngressRules adds an ingress rule allowing Prometheus scraping on the metrics port.

--- a/pkg/deploy/plugins/networkpolicy_transformer_test.go
+++ b/pkg/deploy/plugins/networkpolicy_transformer_test.go
@@ -56,6 +56,7 @@ func TestNetworkPolicyTransformer_Default(t *testing.T) {
 		InstanceName:      "test-instance",
 		ServicePort:       8321,
 		OperatorNamespace: "operator-ns",
+		PraxisMode:        true,
 		NetworkSpec:       nil, // No network spec
 	})
 
@@ -72,15 +73,20 @@ func TestNetworkPolicyTransformer_Default(t *testing.T) {
 	// Should have pod selector with instance name
 	assert.Contains(t, yamlStr, "app.kubernetes.io/instance: test-instance")
 
-	// Should have ingress rules with default peers
-	assert.Contains(t, yamlStr, "podSelector: {}")
+	// Default ingress allows only Praxis pods (fail-safe label) plus the operator namespace.
+	assert.Contains(t, yamlStr, "app: payload-processing")
 	assert.Contains(t, yamlStr, "kubernetes.io/metadata.name: operator-ns")
+
+	// Must NOT allow all pods in the same namespace, nor the OpenShift router.
+	assert.NotContains(t, yamlStr, "podSelector: {}")
+	assert.NotContains(t, yamlStr, "network.openshift.io/policy-group: ingress")
 
 	// Should have port rule
 	assert.Contains(t, yamlStr, "port: 8321")
 }
 
-// TestNetworkPolicyTransformer_ExplicitIngressFromCR uses v1beta1 NetworkPolicySpec.Ingress verbatim.
+// TestNetworkPolicyTransformer_ExplicitIngressFromCR verifies user ingress rules are appended
+// additively on top of the mandatory Praxis + operator peers (rather than replacing them).
 func TestNetworkPolicyTransformer_ExplicitIngressFromCR(t *testing.T) {
 	rf := resource.NewFactory(nil)
 	res, err := rf.FromBytes([]byte(networkPolicyTestYAML))
@@ -108,6 +114,7 @@ func TestNetworkPolicyTransformer_ExplicitIngressFromCR(t *testing.T) {
 		InstanceName:      "test-instance",
 		ServicePort:       8321,
 		OperatorNamespace: "operator-ns",
+		PraxisMode:        true,
 		NetworkSpec: &ogxiov1beta1.NetworkSpec{
 			Policy: &ogxiov1beta1.NetworkPolicySpec{
 				Ingress: ingress,
@@ -123,7 +130,11 @@ func TestNetworkPolicyTransformer_ExplicitIngressFromCR(t *testing.T) {
 	require.NoError(t, err)
 	yamlStr := string(yamlBytes)
 
+	// User rule is present...
 	assert.Contains(t, yamlStr, "namespaceSelector: {}")
+	// ...and the mandatory Praxis + operator peers are still present (additive, not replacing).
+	assert.Contains(t, yamlStr, "app: payload-processing")
+	assert.Contains(t, yamlStr, "kubernetes.io/metadata.name: operator-ns")
 }
 
 func TestNetworkPolicyTransformer_CustomPort(t *testing.T) {
@@ -138,6 +149,7 @@ func TestNetworkPolicyTransformer_CustomPort(t *testing.T) {
 		InstanceName:      "test-instance",
 		ServicePort:       9000,
 		OperatorNamespace: "operator-ns",
+		PraxisMode:        true,
 		NetworkSpec:       nil,
 	})
 
@@ -154,35 +166,46 @@ func TestNetworkPolicyTransformer_CustomPort(t *testing.T) {
 	assert.Contains(t, yamlStr, "port: 9000")
 }
 
-func TestNetworkPolicyTransformer_RouterPeersWhenNetworkSpecProvided(t *testing.T) {
-	rf := resource.NewFactory(nil)
-	res, err := rf.FromBytes([]byte(networkPolicyTestYAML))
-	require.NoError(t, err)
+// TestNetworkPolicyTransformer_NoRouterPeers verifies the OpenShift router peer is never
+// emitted — OGX is internal-only, so no external ingress-controller traffic is admitted,
+// whether or not a NetworkSpec is provided.
+func TestNetworkPolicyTransformer_NoRouterPeers(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		network *ogxiov1beta1.NetworkSpec
+	}{
+		{name: "network spec provided", network: &ogxiov1beta1.NetworkSpec{}},
+		{name: "network spec nil", network: nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rf := resource.NewFactory(nil)
+			res, err := rf.FromBytes([]byte(networkPolicyTestYAML))
+			require.NoError(t, err)
 
-	rm := resmap.New()
-	require.NoError(t, rm.Append(res))
+			rm := resmap.New()
+			require.NoError(t, rm.Append(res))
 
-	transformer := CreateNetworkPolicyTransformer(NetworkPolicyTransformerConfig{
-		InstanceName:      "test-instance",
-		ServicePort:       8321,
-		OperatorNamespace: "operator-ns",
-		NetworkSpec:       &ogxiov1beta1.NetworkSpec{},
-	})
+			transformer := CreateNetworkPolicyTransformer(NetworkPolicyTransformerConfig{
+				InstanceName:      "test-instance",
+				ServicePort:       8321,
+				OperatorNamespace: "operator-ns",
+				PraxisMode:        true,
+				NetworkSpec:       tc.network,
+			})
 
-	err = transformer.Transform(rm)
-	require.NoError(t, err)
+			require.NoError(t, transformer.Transform(rm))
 
-	transformedRes := rm.Resources()[0]
-	yamlBytes, err := transformedRes.AsYAML()
-	require.NoError(t, err)
+			yamlBytes, err := rm.Resources()[0].AsYAML()
+			require.NoError(t, err)
 
-	yamlStr := string(yamlBytes)
-
-	// Should have OpenShift router namespace selector when network spec is provided
-	assert.Contains(t, yamlStr, "network.openshift.io/policy-group: ingress")
+			assert.NotContains(t, string(yamlBytes), "network.openshift.io/policy-group: ingress")
+		})
+	}
 }
 
-func TestNetworkPolicyTransformer_NoRouterPeersWhenNetworkSpecNil(t *testing.T) {
+// TestNetworkPolicyTransformer_PraxisPeerFromConfig verifies a configured Praxis peer is used
+// verbatim in place of the fail-safe default.
+func TestNetworkPolicyTransformer_PraxisPeerFromConfig(t *testing.T) {
 	rf := resource.NewFactory(nil)
 	res, err := rf.FromBytes([]byte(networkPolicyTestYAML))
 	require.NoError(t, err)
@@ -194,20 +217,27 @@ func TestNetworkPolicyTransformer_NoRouterPeersWhenNetworkSpecNil(t *testing.T) 
 		InstanceName:      "test-instance",
 		ServicePort:       8321,
 		OperatorNamespace: "operator-ns",
-		NetworkSpec:       nil,
+		PraxisMode:        true,
+		PraxisPeer: &networkingv1.NetworkPolicyPeer{
+			NamespaceSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"kubernetes.io/metadata.name": "praxis-ns"},
+			},
+			PodSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "custom-praxis"},
+			},
+		},
 	})
 
-	err = transformer.Transform(rm)
-	require.NoError(t, err)
+	require.NoError(t, transformer.Transform(rm))
 
-	transformedRes := rm.Resources()[0]
-	yamlBytes, err := transformedRes.AsYAML()
+	yamlBytes, err := rm.Resources()[0].AsYAML()
 	require.NoError(t, err)
-
 	yamlStr := string(yamlBytes)
 
-	// Should NOT have OpenShift router namespace selector when network spec is nil
-	assert.NotContains(t, yamlStr, "network.openshift.io/policy-group: ingress")
+	assert.Contains(t, yamlStr, "kubernetes.io/metadata.name: praxis-ns")
+	assert.Contains(t, yamlStr, "app: custom-praxis")
+	// The fail-safe default must not appear when a peer is configured.
+	assert.NotContains(t, yamlStr, "app: payload-processing")
 }
 
 func TestNetworkPolicyTransformer_MonitoringIngressWhenMetricsPortSet(t *testing.T) {
@@ -222,6 +252,7 @@ func TestNetworkPolicyTransformer_MonitoringIngressWhenMetricsPortSet(t *testing
 		InstanceName:      "test-instance",
 		ServicePort:       8321,
 		OperatorNamespace: "operator-ns",
+		PraxisMode:        true,
 		NetworkSpec:       nil,
 		MetricsPort:       9464,
 	})
@@ -251,6 +282,7 @@ func TestNetworkPolicyTransformer_NoMonitoringIngressWhenMetricsPortZero(t *test
 		InstanceName:      "test-instance",
 		ServicePort:       8321,
 		OperatorNamespace: "operator-ns",
+		PraxisMode:        true,
 		NetworkSpec:       nil,
 		MetricsPort:       0,
 	})
@@ -265,4 +297,79 @@ func TestNetworkPolicyTransformer_NoMonitoringIngressWhenMetricsPortZero(t *test
 	yamlStr := string(yamlBytes)
 
 	assert.NotContains(t, yamlStr, "network.openshift.io/policy-group: monitoring")
+}
+
+// TestNetworkPolicyTransformer_LegacyMode verifies that with PraxisMode disabled the transformer
+// preserves the pre-Praxis behavior: the same-namespace peer and the OpenShift router peer are
+// emitted, and the Praxis peer is not.
+func TestNetworkPolicyTransformer_LegacyMode(t *testing.T) {
+	rf := resource.NewFactory(nil)
+	res, err := rf.FromBytes([]byte(networkPolicyTestYAML))
+	require.NoError(t, err)
+
+	rm := resmap.New()
+	require.NoError(t, rm.Append(res))
+
+	transformer := CreateNetworkPolicyTransformer(NetworkPolicyTransformerConfig{
+		InstanceName:      "test-instance",
+		ServicePort:       8321,
+		OperatorNamespace: "operator-ns",
+		// NetworkSpec present so the legacy router peer is included.
+		NetworkSpec: &ogxiov1beta1.NetworkSpec{},
+		PraxisMode:  false,
+	})
+
+	require.NoError(t, transformer.Transform(rm))
+
+	yamlBytes, err := rm.Resources()[0].AsYAML()
+	require.NoError(t, err)
+	yamlStr := string(yamlBytes)
+
+	// Legacy peers: same-namespace and OpenShift router.
+	assert.Contains(t, yamlStr, "podSelector: {}")
+	assert.Contains(t, yamlStr, "network.openshift.io/policy-group: ingress")
+	assert.Contains(t, yamlStr, "kubernetes.io/metadata.name: operator-ns")
+
+	// The Praxis fail-safe peer must NOT appear in legacy mode.
+	assert.NotContains(t, yamlStr, "app: payload-processing")
+}
+
+// TestNetworkPolicyTransformer_LegacyModeUserIngressReplaces verifies that in legacy mode
+// user-provided ingress rules fully replace the defaults (pre-Praxis semantics).
+func TestNetworkPolicyTransformer_LegacyModeUserIngressReplaces(t *testing.T) {
+	rf := resource.NewFactory(nil)
+	res, err := rf.FromBytes([]byte(networkPolicyTestYAML))
+	require.NoError(t, err)
+
+	rm := resmap.New()
+	require.NoError(t, rm.Append(res))
+
+	proto := corev1.ProtocolTCP
+	ingress := []networkingv1.NetworkPolicyIngressRule{
+		{
+			From:  []networkingv1.NetworkPolicyPeer{{NamespaceSelector: &metav1.LabelSelector{}}},
+			Ports: []networkingv1.NetworkPolicyPort{{Protocol: &proto, Port: &intstr.IntOrString{Type: intstr.Int, IntVal: 8321}}},
+		},
+	}
+
+	transformer := CreateNetworkPolicyTransformer(NetworkPolicyTransformerConfig{
+		InstanceName:      "test-instance",
+		ServicePort:       8321,
+		OperatorNamespace: "operator-ns",
+		NetworkSpec: &ogxiov1beta1.NetworkSpec{
+			Policy: &ogxiov1beta1.NetworkPolicySpec{Ingress: ingress},
+		},
+		PraxisMode: false,
+	})
+
+	require.NoError(t, transformer.Transform(rm))
+
+	yamlBytes, err := rm.Resources()[0].AsYAML()
+	require.NoError(t, err)
+	yamlStr := string(yamlBytes)
+
+	// User rule present; defaults (operator namespace peer) replaced, not appended.
+	assert.Contains(t, yamlStr, "namespaceSelector: {}")
+	assert.NotContains(t, yamlStr, "kubernetes.io/metadata.name: operator-ns")
+	assert.NotContains(t, yamlStr, "app: payload-processing")
 }

--- a/release/operator-openshift.yaml
+++ b/release/operator-openshift.yaml
@@ -377,8 +377,9 @@ spec:
                         type: boolean
                       ingress:
                         description: |-
-                          Ingress defines additional ingress rules, merged with operator defaults
-                          (allow from same-namespace and operator-namespace on the service port).
+                          Ingress defines additional ingress rules, appended to the mandatory operator rules
+                          (allow from Praxis pods and the operator namespace on the service port). User rules
+                          are additive and cannot remove the mandatory Praxis lock-down.
                         items:
                           description: |-
                             NetworkPolicyIngressRule describes a particular set of traffic that is allowed to the pods

--- a/release/operator.yaml
+++ b/release/operator.yaml
@@ -378,8 +378,9 @@ spec:
                         type: boolean
                       ingress:
                         description: |-
-                          Ingress defines additional ingress rules, merged with operator defaults
-                          (allow from same-namespace and operator-namespace on the service port).
+                          Ingress defines additional ingress rules, appended to the mandatory operator rules
+                          (allow from Praxis pods and the operator namespace on the service port). User rules
+                          are additive and cannot remove the mandatory Praxis lock-down.
                         items:
                           description: |-
                             NetworkPolicyIngressRule describes a particular set of traffic that is allowed to the pods

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -25,6 +25,9 @@ func TestE2E(t *testing.T) {
 	t.Run("tls", func(t *testing.T) {
 		TestTLSSuite(t)
 	})
+
+	// Run NetworkPolicy internal-only enforcement tests
+	t.Run("network-policy", TestNetworkPolicySuite)
 }
 
 // runCreationDeletionSuiteForDistribution runs creation tests followed by deletion tests for a specific distribution.

--- a/tests/e2e/network_policy_test.go
+++ b/tests/e2e/network_policy_test.go
@@ -1,0 +1,255 @@
+//nolint:testpackage
+package e2e
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	ogxiov1beta1 "github.com/ogx-ai/ogx-k8s-operator/api/v1beta1"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+const (
+	// npEnforcementEnvVar gates the CNI-dependent traffic-blocking test. It only produces a
+	// meaningful result on a policy-enforcing CNI (OVN-Kubernetes / Calico); on non-enforcing
+	// CNIs such as kind's kindnet the NetworkPolicy object exists but nothing is blocked.
+	npEnforcementEnvVar = "OGX_E2E_TEST_NP_ENFORCEMENT"
+
+	praxisLabelKey   = "app"
+	praxisLabelValue = "payload-processing"
+)
+
+// TestNetworkPolicySuite verifies OGX is enforced internal-only: the operator-managed
+// NetworkPolicy admits traffic only from Praxis pods plus the operator namespace, no external
+// exposure (Ingress) is created even when requested, and the status reflects internal-only.
+func TestNetworkPolicySuite(t *testing.T) {
+	if TestOpts.SkipCreation {
+		t.Skip("Skipping NetworkPolicy suite (SkipCreation=true)")
+	}
+
+	nsName := "ogx-np-test"
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: nsName}}
+	err := TestEnv.Client.Create(TestEnv.Ctx, ns)
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		require.NoError(t, err)
+	}
+
+	server := GetSampleCRForDistribution(t, starterDistType)
+	server.Name = "ogx-np"
+	server.Namespace = nsName
+	// Force the Praxis-fronted posture (the deployed webhook would default this on create, but be
+	// explicit so the suite is deterministic regardless of webhook availability). The fail-safe
+	// Praxis peer pins the openshift-ingress namespace, but this suite runs its connectivity probes
+	// in the test namespace, so set a per-CR praxisSelector admitting Praxis-labeled pods from the
+	// test namespace. This also exercises the spec.praxisMode.praxisSelector override path.
+	praxisOn := true
+	server.Spec.PraxisMode = &ogxiov1beta1.PraxisModeSpec{
+		Enabled: &praxisOn,
+		PraxisSelector: &ogxiov1beta1.PraxisSelector{
+			Namespace:   nsName,
+			PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{praxisLabelKey: praxisLabelValue}},
+		},
+	}
+	// Request external access explicitly to prove it is NOT honored (internal-only).
+	if server.Spec.Network == nil {
+		server.Spec.Network = &ogxiov1beta1.NetworkSpec{}
+	}
+	server.Spec.Network.ExternalAccess = &ogxiov1beta1.ExternalAccessConfig{Enabled: true}
+
+	EnsureOverrideConfigMap(t, TestEnv.Client, TestEnv.Ctx, server)
+	require.NoError(t, TestEnv.Client.Create(TestEnv.Ctx, server))
+
+	t.Cleanup(func() {
+		_ = TestEnv.Client.Delete(context.Background(), server)
+		_ = TestEnv.Client.Delete(context.Background(), ns)
+	})
+
+	npName := server.Name + "-network-policy"
+
+	t.Run("NetworkPolicy admits only Praxis and operator peers", func(t *testing.T) {
+		np := waitForNetworkPolicy(t, nsName, npName)
+
+		require.NotEmpty(t, np.Spec.Ingress, "NetworkPolicy should have ingress rules")
+
+		require.True(t, hasPraxisPeer(np), "NetworkPolicy must allow ingress from Praxis pods (%s=%s)", praxisLabelKey, praxisLabelValue)
+		require.True(t, hasOperatorNamespacePeer(np, TestOpts.OperatorNS), "NetworkPolicy must allow ingress from the operator namespace")
+		require.False(t, hasSameNamespacePeer(np), "NetworkPolicy must NOT allow ingress from all pods in the same namespace")
+		require.False(t, hasRouterPeer(np), "NetworkPolicy must NOT allow ingress from the OpenShift router")
+	})
+
+	t.Run("no external Ingress is created", func(t *testing.T) {
+		var ing networkingv1.Ingress
+		getErr := TestEnv.Client.Get(TestEnv.Ctx, types.NamespacedName{
+			Name:      server.Name + "-ingress",
+			Namespace: nsName,
+		}, &ing)
+		require.True(t, apierrors.IsNotFound(getErr),
+			"no Ingress should exist even though externalAccess.enabled=true; got err=%v", getErr)
+	})
+
+	t.Run("status is internal-only", func(t *testing.T) {
+		err := wait.PollUntilContextTimeout(TestEnv.Ctx, generalRetryInterval, ResourceReadyTimeout, true,
+			func(ctx context.Context) (bool, error) {
+				fetched := &ogxiov1beta1.OGXServer{}
+				if getErr := TestEnv.Client.Get(ctx, types.NamespacedName{Name: server.Name, Namespace: nsName}, fetched); getErr != nil {
+					if apierrors.IsNotFound(getErr) {
+						return false, nil
+					}
+					return false, getErr
+				}
+				return fetched.Status.ServiceURL != "", nil
+			})
+		require.NoError(t, err, "status.serviceURL should be populated with the internal endpoint")
+
+		fetched := &ogxiov1beta1.OGXServer{}
+		require.NoError(t, TestEnv.Client.Get(TestEnv.Ctx, types.NamespacedName{Name: server.Name, Namespace: nsName}, fetched))
+		require.Contains(t, fetched.Status.ServiceURL, ".svc.cluster.local", "serviceURL should be the internal cluster DNS endpoint")
+		require.Nil(t, fetched.Status.ExternalURL, "externalURL must be empty for internal-only OGX")
+	})
+
+	t.Run("traffic enforcement (CNI-dependent)", func(t *testing.T) {
+		if os.Getenv(npEnforcementEnvVar) != "true" {
+			t.Skipf("Skipping NetworkPolicy traffic-enforcement test; set %s=true to run on a policy-enforcing CNI "+
+				"(OVN-Kubernetes / Calico). This is the strategy's 'validated assumption' and does not hold on kindnet.",
+				npEnforcementEnvVar)
+		}
+		runTrafficEnforcementTest(t, server)
+	})
+}
+
+func waitForNetworkPolicy(t *testing.T, namespace, name string) *networkingv1.NetworkPolicy {
+	t.Helper()
+	np := &networkingv1.NetworkPolicy{}
+	err := wait.PollUntilContextTimeout(TestEnv.Ctx, generalRetryInterval, ResourceReadyTimeout, true,
+		func(ctx context.Context) (bool, error) {
+			if getErr := TestEnv.Client.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, np); getErr != nil {
+				if apierrors.IsNotFound(getErr) {
+					return false, nil
+				}
+				return false, getErr
+			}
+			return true, nil
+		})
+	require.NoError(t, err, "NetworkPolicy %s/%s should be created", namespace, name)
+	return np
+}
+
+func hasPraxisPeer(np *networkingv1.NetworkPolicy) bool {
+	for _, rule := range np.Spec.Ingress {
+		for _, peer := range rule.From {
+			if peer.PodSelector != nil && peer.PodSelector.MatchLabels[praxisLabelKey] == praxisLabelValue {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func hasOperatorNamespacePeer(np *networkingv1.NetworkPolicy, operatorNS string) bool {
+	for _, rule := range np.Spec.Ingress {
+		for _, peer := range rule.From {
+			if peer.NamespaceSelector != nil &&
+				peer.NamespaceSelector.MatchLabels["kubernetes.io/metadata.name"] == operatorNS {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func hasSameNamespacePeer(np *networkingv1.NetworkPolicy) bool {
+	for _, rule := range np.Spec.Ingress {
+		for _, peer := range rule.From {
+			if peer.PodSelector != nil && len(peer.PodSelector.MatchLabels) == 0 &&
+				len(peer.PodSelector.MatchExpressions) == 0 && peer.NamespaceSelector == nil {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func hasRouterPeer(np *networkingv1.NetworkPolicy) bool {
+	for _, rule := range np.Spec.Ingress {
+		for _, peer := range rule.From {
+			if peer.NamespaceSelector != nil &&
+				peer.NamespaceSelector.MatchLabels["network.openshift.io/policy-group"] == "ingress" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// runTrafficEnforcementTest verifies that, on a policy-enforcing CNI, a pod without the Praxis
+// label is blocked from reaching OGX on 8321 while a pod carrying the label succeeds. It waits
+// for the OGX deployment to be ready first so the Service has endpoints.
+func runTrafficEnforcementTest(t *testing.T, server *ogxiov1beta1.OGXServer) {
+	t.Helper()
+
+	require.NoError(t, WaitForPodsReady(t, TestEnv, server.Namespace, server.Name, ResourceReadyTimeout),
+		"OGX pods must be ready before probing connectivity")
+
+	serviceHost := server.Name + "-service." + server.Namespace + ".svc.cluster.local"
+
+	allowedExit := runConnectivityProbe(t, "np-probe-allowed", server.Namespace, serviceHost,
+		map[string]string{praxisLabelKey: praxisLabelValue})
+	require.Equal(t, int32(0), allowedExit, "a pod labeled %s=%s should reach OGX on 8321", praxisLabelKey, praxisLabelValue)
+
+	blockedExit := runConnectivityProbe(t, "np-probe-blocked", server.Namespace, serviceHost, nil)
+	require.NotEqual(t, int32(0), blockedExit, "a pod without the Praxis label must be blocked from OGX on 8321")
+}
+
+// runConnectivityProbe creates a short-lived pod that attempts a TCP connection to the OGX
+// service port and returns its container exit code (0 = connected, non-zero = blocked/failed).
+func runConnectivityProbe(t *testing.T, name, namespace, serviceHost string, labels map[string]string) int32 {
+	t.Helper()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, Labels: labels},
+		Spec: corev1.PodSpec{
+			RestartPolicy: corev1.RestartPolicyNever,
+			Containers: []corev1.Container{
+				{
+					Name:    "probe",
+					Image:   "busybox:1.36",
+					Command: []string{"sh", "-c", "nc -z -w 5 " + serviceHost + " 8321"},
+				},
+			},
+		},
+	}
+
+	_ = TestEnv.Client.Delete(TestEnv.Ctx, pod)
+	require.NoError(t, TestEnv.Client.Create(TestEnv.Ctx, pod))
+	t.Cleanup(func() { _ = TestEnv.Client.Delete(context.Background(), pod) })
+
+	var exitCode int32 = -1
+	err := wait.PollUntilContextTimeout(TestEnv.Ctx, generalRetryInterval, 3*time.Minute, true,
+		func(ctx context.Context) (bool, error) {
+			fetched := &corev1.Pod{}
+			if getErr := TestEnv.Client.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, fetched); getErr != nil {
+				if apierrors.IsNotFound(getErr) {
+					return false, nil
+				}
+				return false, getErr
+			}
+			for _, cs := range fetched.Status.ContainerStatuses {
+				if cs.State.Terminated != nil {
+					exitCode = cs.State.Terminated.ExitCode
+					return true, nil
+				}
+			}
+			return false, nil
+		})
+	require.NoError(t, err, "connectivity probe pod %s did not terminate in time", name)
+	t.Logf("connectivity probe %s exited with code %d", name, exitCode)
+	return exitCode
+}


### PR DESCRIPTION
## What

Adds an explicit **Praxis-fronted, internal-only deployment mode** to the OGX operator. OGX is an internal backend fronted by Praxis (the public entrypoint); in this mode the operator restricts OGX so it cannot be reached directly (bypassing Praxis auth/tenant normalization) or exposed externally.

This PR delivers **RHAIENG-6736** (internal-only deployment mode), which now subsumes **RHAIENG-6663** (Praxis-only NetworkPolicy ingress).

> **Depends on #355** (RHAIENG-7193), which introduces the `spec.praxisMode` API (`enabled`, `praxisSelector`, `migrationJob`) and the mutating webhook defaulter. This PR is stacked on that branch and only wires the operator to consume it. Retarget to `main` once #355 merges.

## Mode selection (`spec.praxisMode.enabled`, upgrade-safe)

Tri-state, resolved per-CR — no reconciliation state is derived from `status`:

- **`true`** — Praxis-fronted (internal-only).
- **`false`** — legacy behavior.
- **unset** — new CRs get `enabled` defaulted to `true` on create by #355's mutating webhook (greenfield → Praxis mode); CRs predating the webhook keep an unset value and are treated as **legacy**, so an operator upgrade never silently cuts off co-located workloads. Because defaulting is per-CR at create time, OGXServers migrate independently.

## Changes

- **Consume #355's API** — dropped this branch's own `spec.praxisMode *bool` field, its mutating defaulter, and the operator-wide `praxis-peer` ConfigMap mechanism in favor of #355's `spec.praxisMode` struct.
- **Per-CR Praxis peer** — the NetworkPolicy Praxis ingress peer is built from **`spec.praxisMode.praxisSelector`** (namespace + pod selector), so different OGXServers can front different Praxis instances (addresses @VaishnaviHire and @eoinfennessy's per-CR / multiple-Praxis-instances point). Falls back to `app: payload-processing` in `openshift-ingress` when unset; never emits an allow-all peer (the selector is CEL-validated non-empty in #355).
- **Praxis mode NetworkPolicy** — ingress on `8321` admits only the Praxis peer + the operator namespace (control-plane status polling). The broad same-namespace peer and OpenShift-router peer are removed. `spec.network.policy.ingress` rules are **additive** on top of the mandatory lock-down. `policy.enabled: false` still fully disables the policy.
- **Enforced internal-only external access (Praxis mode)** — the operator never creates an Ingress and removes any it previously created; `status.externalURL` is cleared while `status.serviceURL` keeps the internal cluster DNS endpoint. `spec.network.externalAccess.enabled: true` is not honored and surfaces an admission **warning** (not a rejection).
- **Responses API** — disabled in the generated config in Praxis mode (served by Praxis); applied internally, does not mutate `spec.disabledAPIs`.
- **Legacy mode** — preserves the pre-Praxis peers (same-namespace + OpenShift router) and `externalAccess`-driven Ingress (RHAIENG-6736 AC#8: router peers apply only in legacy mode).

Out of scope here (tracked by RHAIENG-7193/#355): wiring the DB **migration Job** (`spec.praxisMode.migrationJob`) and the target-PostgreSQL instance.

## Testing

- Unit / envtest (all non-e2e packages pass): `resolvePraxisMode` and `BuildPraxisPeer` (praxisSelector→peer mapping + default fallback, never allow-all); NetworkPolicy contains only Praxis + operator peers in Praxis mode and same-namespace + router in legacy; user rules merge additively; no Ingress created even with `externalAccess.enabled: true`; previously-owned Ingress deleted; `status.serviceURL` populated / `status.externalURL` empty; webhook warns (not errors) on `externalAccess.enabled: true`; Responses API disabled in generated config.
- CI-runnable e2e negative suite asserts on-cluster NetworkPolicy shape (now driven by per-CR `praxisSelector`), no Ingress, and internal-only status. The traffic-blocking check stays gated behind `OGX_E2E_TEST_NP_ENFORCEMENT=true` (only meaningful on a policy-enforcing CNI).

## Upgrade note

Breaking in Praxis mode on enforcing-CNI clusters: co-located workloads that reach OGX today (not matched by the Praxis selector, outside the operator namespace) lose access, and any external Ingress is removed. Escape hatches: set `spec.praxisMode.praxisSelector`, add additive `spec.network.policy.ingress` rules, disable the policy with `policy.enabled: false`, or run legacy mode (`spec.praxisMode.enabled: false`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
