### PR TITLE
fix(controller): use Recreate deployment strategy to prevent PVC locking conflicts

### DIFF
--- a/controllers/llamastackdistribution_controller.go
+++ b/controllers/llamastackdistribution_controller.go
@@ -802,6 +802,9 @@ func (r *LlamaStackDistributionReconciler) reconcileDeployment(ctx context.Conte
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &instance.Spec.Replicas,
+			Strategy: appsv1.DeploymentStrategy{
+				Type: appsv1.RecreateDeploymentStrategyType,
+			},
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					llamav1alpha1.DefaultLabelKey: llamav1alpha1.DefaultLabelValue,

--- a/controllers/llamastackdistribution_controller_test.go
+++ b/controllers/llamastackdistribution_controller_test.go
@@ -124,6 +124,8 @@ func TestStorageConfiguration(t *testing.T) {
 			deployment := &appsv1.Deployment{}
 			waitForResource(t, k8sClient, instance.Namespace, instance.Name, deployment)
 
+			AssertDeploymentHasRecreateStrategy(t, deployment)
+
 			if tt.expectedVolume.EmptyDir != nil {
 				AssertDeploymentUsesEmptyDirStorage(t, deployment)
 			} else if tt.expectedVolume.PersistentVolumeClaim != nil {

--- a/controllers/testing_support_test.go
+++ b/controllers/testing_support_test.go
@@ -151,6 +151,12 @@ func AssertDeploymentHasPort(t *testing.T, deployment *appsv1.Deployment, expect
 		"container should expose port %d", expectedPort)
 }
 
+func AssertDeploymentHasRecreateStrategy(t *testing.T, deployment *appsv1.Deployment) {
+	t.Helper()
+	require.Equal(t, appsv1.RecreateDeploymentStrategyType, deployment.Spec.Strategy.Type,
+		"deployment should use Recreate deployment strategy")
+}
+
 func AssertDeploymentUsesEmptyDirStorage(t *testing.T, deployment *appsv1.Deployment) {
 	t.Helper()
 	volume := findVolumeByName(t, deployment, testStorageVolumeName)


### PR DESCRIPTION
### What this PR does / why we need it
Configures the `LlamaStackDistribution` Deployment to use `strategy.type: Recreate` instead of the default `RollingUpdate`.

### Why
`LlamaStackDistribution` workloads utilize embedded SQLite/Milvus Lite databases on mounted `ReadWriteOnce` PVCs.
When deploying updates or restarting pods, Kubernetes' default `RollingUpdate` strategy (`maxUnavailable: 0`) spins up a new pod while the old pod is still running.
This causes:
1. Multi-Attach volume errors across different nodes when the PVC cannot be attached to two nodes simultaneously.
2. Milvus Lite / SQLite file lock crashes (`ConnectionConfigException: Open milvus.db failed, the file has been opened by another program`) when both pods run on the same node.

Setting `strategy.type: Recreate` guarantees that old pods are completely terminated and volume locks are released before new pods are created.

### How to test
1. Deploy a `LlamaStackDistribution` CR with `storage` configured.
2. Patch an environment variable or field on the CR to trigger a Deployment rollout.
3. Observe that the old pod terminates cleanly before the new pod starts up and mounts the PVC successfully.